### PR TITLE
Make client compatible to API version 0.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake'
-gem 'rspec'
+group :test do
+  gem 'rack-test'
+  gem 'rake'
+  gem 'rspec'
+end

--- a/README.md
+++ b/README.md
@@ -78,10 +78,8 @@ summary.get({ service: 'database' })
 ## Todo
 
   * add push support to a vanilla prometheus exporter
-  * add tests for Rack middlewares
   * use a more performant JSON library
   * add protobuf support
-  * update to recent json format
 
 ## Tests
 

--- a/examples/rack/config.ru
+++ b/examples/rack/config.ru
@@ -4,6 +4,6 @@ require 'rack'
 require 'prometheus/client/rack/collector'
 require 'prometheus/client/rack/exporter'
 
-use Prometheus::Client::Rack::Exporter
 use Prometheus::Client::Rack::Collector
+use Prometheus::Client::Rack::Exporter
 run lambda { |env| [200, {'Content-Type' => 'text/html'}, ['OK']] }

--- a/examples/rack/prometheus.conf
+++ b/examples/rack/prometheus.conf
@@ -1,0 +1,25 @@
+global {
+  scrape_interval: "30s"
+  evaluation_interval: "30s"
+  labels {
+    label {
+      name: "owner"
+      value: "client_ruby test suite"
+    }
+  }
+}
+
+job {
+  name: "prometheus"
+  scrape_interval: "15s"
+  target_group {
+    target: "http://localhost:9090/metrics"
+  }
+}
+
+job {
+  name: "rack-example"
+  target_group {
+      target: "http://localhost:5000/metrics"
+  }
+}

--- a/lib/prometheus/client/rack/collector.rb
+++ b/lib/prometheus/client/rack/collector.rb
@@ -14,15 +14,7 @@ module Prometheus
         end
 
         def call(env) # :nodoc:
-          start = Time.now
-
-          @app.call(env)
-        ensure
-          execution_time = ((Time.now - start) * 1_000_000).to_i
-          label_set = { :method => env['REQUEST_METHOD'] }
-          @requests.increment(label_set)
-          @requests_duration.increment(label_set, execution_time)
-          @latency.add(label_set, execution_time)
+          trace(env) { @app.call(env) }
         end
 
       protected
@@ -30,7 +22,36 @@ module Prometheus
         def init_metrics
           @requests = @registry.counter(:http_requests_total, 'A counter of the total number of HTTP requests made')
           @requests_duration = @registry.counter(:http_request_durations_total_microseconds, 'The total amount of time Rack has spent answering HTTP requests (microseconds).')
-          @latency = @registry.summary(:http_request_latency_microseconds, 'A histogram of the response latency for requests made (microseconds).')
+          @durations = @registry.summary(:http_request_durations_microseconds, 'A histogram of the response latency for requests made (microseconds).')
+        end
+
+        def trace(env, &block)
+          start = Time.now
+          response = yield
+        rescue => exception
+          raise
+        ensure
+          duration = ((Time.now - start) * 1_000_000).to_i
+          record(duration, env, response, exception)
+        end
+
+        def record(duration, env, response, exception)
+          labels = {
+            :method => env['REQUEST_METHOD'].downcase,
+            :path   => env['PATH_INFO'].to_s,
+          }
+
+          if response
+            labels[:code] = response.first.to_s
+          else
+            labels[:exception] = exception.class.name
+          end
+
+          @requests.increment(labels)
+          @requests_duration.increment(labels, duration)
+          @durations.add(labels, duration)
+        rescue => error
+          # TODO: log unexpected exception during request recording
         end
 
       end

--- a/lib/prometheus/client/rack/exporter.rb
+++ b/lib/prometheus/client/rack/exporter.rb
@@ -6,10 +6,14 @@ module Prometheus
       class Exporter
         attr_reader :app, :registry, :path
 
+        API_VERSION  = '0.0.2'
+        CONTENT_TYPE = 'application/json; schema="prometheus/telemetry"; version=' + API_VERSION
+        HEADERS      = { 'Content-Type' => CONTENT_TYPE }
+
         def initialize(app, options = {})
           @app = app
           @registry = options[:registry] || Client.registry
-          @path = options[:path] || '/metrics.json'
+          @path = options[:path] || '/metrics'
         end
 
         def call(env)
@@ -23,13 +27,7 @@ module Prometheus
       protected
 
         def metrics_response
-          json = @registry.to_json
-          headers = {
-            'Content-Type' => 'application/json',
-            'Content-Length' => json.size.to_s
-          }
-
-          [200, headers, [json]]
+          [200, HEADERS, [@registry.to_json]]
         end
 
       end

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -5,7 +5,7 @@ module Prometheus
   module Client
     class Summary < Metric
       def type
-        :summary
+        :histogram
       end
 
       # Records a given value.

--- a/spec/prometheus/client/rack/collector_spec.rb
+++ b/spec/prometheus/client/rack/collector_spec.rb
@@ -1,0 +1,65 @@
+require_relative '../../../../lib/prometheus/client/rack/collector'
+require 'rack/test'
+
+describe Prometheus::Client::Rack::Collector do
+  include Rack::Test::Methods
+
+  let(:registry) do
+    Prometheus::Client::Registry.new
+  end
+
+  let(:app) do
+    app = lambda { |env| [200, {'Content-Type' => 'text/html'}, ['OK']] }
+    Prometheus::Client::Rack::Collector.new(app, registry: registry)
+  end
+
+  it 'returns the app response' do
+    get '/foo'
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to eql('OK')
+  end
+
+  it 'handles errors in the registry gracefully' do
+    app
+    registry.get(:http_requests_total).metric.should_receive(:increment).and_raise(NoMethodError)
+
+    get '/foo'
+
+    expect(last_response).to be_ok
+  end
+
+  it 'traces request information' do
+    Time.should_receive(:now).twice.and_return(0.0, 0.000042)
+    expected_labels = { method: 'get', path: '/foo', code: '200' }
+
+    get '/foo'
+
+    expect(registry.to_json).to eql([
+      {
+        baseLabels: { name: 'http_requests_total' },
+        docstring: 'A counter of the total number of HTTP requests made',
+        metric: {
+          type: 'counter',
+          value: [{ labels: expected_labels, value: 1 }]
+        }
+      },
+      {
+        baseLabels: { name: 'http_request_durations_total_microseconds' },
+        docstring: 'The total amount of time Rack has spent answering HTTP requests (microseconds).',
+        metric: {
+          type: 'counter',
+          value: [{ labels: expected_labels, value: 42 }]
+        }
+      },
+      {
+        baseLabels: { name: 'http_request_durations_microseconds' },
+        docstring: 'A histogram of the response latency for requests made (microseconds).',
+        metric: {
+          type: 'histogram',
+          value: [{ labels: expected_labels, value: { '0.5' => 42, '0.9' => 42, '0.99' => 42 } }]
+        }
+      }
+    ].to_json)
+  end
+end

--- a/spec/prometheus/client/rack/exporter_spec.rb
+++ b/spec/prometheus/client/rack/exporter_spec.rb
@@ -1,0 +1,48 @@
+require_relative '../../../../lib/prometheus/client/rack/exporter'
+require 'rack/test'
+
+describe Prometheus::Client::Rack::Exporter do
+  include Rack::Test::Methods
+
+  let(:registry) do
+    Prometheus::Client::Registry.new
+  end
+
+  let(:app) do
+    app = lambda { |env| [200, {'Content-Type' => 'text/html'}, ['OK']] }
+    Prometheus::Client::Rack::Exporter.new(app, registry: registry)
+  end
+
+  context 'when requesting app endpoints' do
+    it 'returns the app response' do
+      get '/foo'
+
+      expect(last_response).to be_ok
+      expect(last_response.body).to eql('OK')
+    end
+  end
+
+  context 'when requesting /metrics' do
+    it 'returns a prometheus compatible json response' do
+      registry.counter(:foo, 'foo counter').increment({}, 9)
+
+      get '/metrics'
+
+      expect(last_response).to be_ok
+      expected_content_type = 'application/json; schema="prometheus/telemetry"; version=0.0.2'
+      expect(last_response.header['Content-Type']).to eql(expected_content_type)
+      expect(last_response.body).to eql([
+        {
+          baseLabels: { name: 'foo' },
+          docstring: 'foo counter',
+          metric: {
+            type: 'counter',
+            value: [
+              { labels: {}, value: 9 }
+            ]
+          }
+        }
+      ].to_json)
+    end
+  end
+end

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -9,6 +9,12 @@ module Prometheus::Client
       let(:type) { Hash }
     end
 
+    describe '#type' do
+      it 'returns histogram for API compatibility' do
+        expect(summary.type).to eql(:histogram)
+      end
+    end
+
     describe '#add' do
       it 'records the given value' do
         expect do


### PR DESCRIPTION
This change makes the ruby client JSON API 0.0.2 compatible. The following changes were necessary
- Rename type `summary` to `histogram` until API 0.0.3 is released and supported
- Set correct `Content-Type` header

Minor changes to be compatible with the golang client label naming:
- Rename `http_request_latency_microseconds` to `http_request_durations_microseconds`
- Add `method`, `path` and `code` labels

Misc:
- Add missing tests for middlewares

While protobuf support is still missing, this makes the client fully useable with current prometheus servers. An example prometheus.conf has been added for manual verification, full integration tests will come in the future.

@matttproud 
