### PR TITLE
Add support for text format

### DIFF
--- a/lib/prometheus/client/formats/json.rb
+++ b/lib/prometheus/client/formats/json.rb
@@ -24,10 +24,6 @@ module Prometheus
             }
           end.to_json
         end
-
-        def self.unmarshal(*)
-          fail NotImplementedError
-        end
       end
     end
   end

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -1,0 +1,68 @@
+# encoding: UTF-8
+
+module Prometheus
+  module Client
+    module Formats
+      # Text format is human readable mainly used for manual inspection.
+      module Text
+        VERSION = '0.0.4'
+        TYPE    = 'text/plain; version=' + VERSION
+
+        METRIC_LINE = '%s%s %s'
+        TYPE_LINE   = '# TYPE %s %s'
+        HELP_LINE   = '# HELP %s %s'
+
+        LABEL     = '%s="%s"'
+        SEPARATOR = ','
+        DELIMITER = "\n"
+
+        REGEX   = { doc: /[\n\\]/, label: /[\n\\"]/ }
+        REPLACE = { "\n" => '\n', '\\' => '\\\\', '"' => '\"' }
+
+        def self.marshal(registry)
+          lines = []
+
+          registry.metrics.each do |metric|
+            lines << format(TYPE_LINE, metric.name, metric.type)
+            lines << format(HELP_LINE, metric.name, escape(metric.docstring))
+
+            metric.values.each do |label_set, value|
+              set = metric.base_labels.merge(label_set)
+              representation(metric.name, set, value) { |l| lines << l }
+            end
+          end
+
+          # there must be a trailing delimiter
+          (lines << nil).join(DELIMITER)
+        end
+
+        private
+
+        def self.representation(name, set, value)
+          if value.is_a?(Hash)
+            value.each do |quantile, v|
+              l = labels(set.merge(quantile: quantile))
+              yield format(METRIC_LINE, name, l, v)
+            end
+          else
+            yield format(METRIC_LINE, name, labels(set), value)
+          end
+        end
+
+        def self.labels(set)
+          return if set.empty?
+
+          strings = set.reduce([]) do |memo, (key, value)|
+            memo << format(LABEL, key, escape(value, :label))
+          end
+
+          "{#{strings.join(SEPARATOR)}}"
+        end
+
+        def self.escape(string, format = :doc)
+          string.to_s.gsub(REGEX[format], REPLACE)
+        end
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/rack/exporter.rb
+++ b/lib/prometheus/client/rack/exporter.rb
@@ -2,6 +2,7 @@
 
 require 'prometheus/client'
 require 'prometheus/client/formats/json'
+require 'prometheus/client/formats/text'
 
 module Prometheus
   module Client
@@ -12,6 +13,10 @@ module Prometheus
       class Exporter
         attr_reader :app, :registry, :path
 
+        AVAILABLE = [Formats::Text, Formats::JSON]
+        FORMATS   = AVAILABLE.reduce({}) { |a, e| a.merge(e::TYPE => e) }
+        FALLBACK  = Formats::JSON
+
         def initialize(app, options = {})
           @app = app
           @registry = options[:registry] || Client.registry
@@ -20,15 +25,35 @@ module Prometheus
 
         def call(env)
           if env['PATH_INFO'] == @path
-            response(Formats::JSON)
+            format = negotiate(env['HTTP_ACCEPT'], FORMATS, FALLBACK)
+            respond_with(format)
           else
             @app.call(env)
           end
         end
 
-        protected
+        private
 
-        def response(format)
+        def negotiate(accept, formats, fallback)
+          parse(accept).each do |content_type, _|
+            return formats[content_type] if formats.key?(content_type)
+          end
+
+          fallback
+        end
+
+        def parse(header)
+          header.to_s.split(/\s*,\s*/).map do |type|
+            attributes = type.split(/\s*;\s*/)
+            quality = 1.0
+            attributes.delete_if do |attr|
+              quality = attr.split('q=').last.to_f if attr.start_with?('q=')
+            end
+            [attributes.join('; '), quality]
+          end.sort_by(&:last).reverse
+        end
+
+        def respond_with(format)
           [
             200,
             { 'Content-Type' => format::TYPE },

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -1,0 +1,59 @@
+# encoding: UTF-8
+
+require 'prometheus/client/formats/text'
+
+describe Prometheus::Client::Formats::Text do
+  let(:registry) do
+    double(metrics: [
+      double(
+        name: :foo,
+        docstring: 'foo description',
+        base_labels: {},
+        type: :counter,
+        values: { { code: 'red' } => 42 },
+      ),
+      double(
+        name: :bar,
+        docstring: "bar description\nwith newline",
+        base_labels: { status: 'success' },
+        type: :gauge,
+        values: { { code: 'pink' } => 15 },
+      ),
+      double(
+        name: :baz,
+        docstring: 'baz "description" \\escaping',
+        base_labels: {},
+        type: :counter,
+        values: { { text: %Q(with "quotes", \\escape \n and newline) } => 15 },
+      ),
+      double(
+        name: :qux,
+        docstring: 'qux description',
+        base_labels: { for: 'sake' },
+        type: :summary,
+        values: { { code: '1' } => { 0.5 => 4.2, 0.9 => 8.32, 0.99 => 15.3 } },
+      ),
+    ],)
+  end
+
+  describe '.marshal' do
+    it 'returns a Text format version 0.0.4 compatible representation' do
+      expect(subject.marshal(registry)).to eql <<-'TEXT'
+# TYPE foo counter
+# HELP foo foo description
+foo{code="red"} 42
+# TYPE bar gauge
+# HELP bar bar description\nwith newline
+bar{status="success",code="pink"} 15
+# TYPE baz counter
+# HELP baz baz "description" \\escaping
+baz{text="with \"quotes\", \\escape \n and newline"} 15
+# TYPE qux summary
+# HELP qux qux description
+qux{for="sake",code="1",quantile="0.5"} 4.2
+qux{for="sake",code="1",quantile="0.9"} 8.32
+qux{for="sake",code="1",quantile="0.99"} 15.3
+      TEXT
+    end
+  end
+end

--- a/spec/prometheus/client/rack/exporter_spec.rb
+++ b/spec/prometheus/client/rack/exporter_spec.rb
@@ -7,10 +7,6 @@ require 'prometheus/client/rack/exporter'
 describe Prometheus::Client::Rack::Exporter do
   include Rack::Test::Methods
 
-  let(:json_content_type) do
-    'application/json; schema="prometheus/telemetry"; version=0.0.2'
-  end
-
   let(:registry) do
     Prometheus::Client::Registry.new
   end
@@ -30,25 +26,65 @@ describe Prometheus::Client::Rack::Exporter do
   end
 
   context 'when requesting /metrics' do
-    it 'returns a prometheus compatible json response' do
-      registry.counter(:foo, 'foo counter').increment({}, 9)
+    text = Prometheus::Client::Formats::Text
+    json = Prometheus::Client::Formats::JSON
 
-      get '/metrics'
+    shared_examples 'response' do |headers, format|
+      it 'returns a valid prometheus compatible response' do
+        registry.counter(:foo, 'foo counter').increment({}, 9)
 
-      expect(last_response).to be_ok
-      expect(last_response.header['Content-Type']).to eql(json_content_type)
-      expect(last_response.body).to eql([
-        {
-          baseLabels: { __name__: 'foo' },
-          docstring: 'foo counter',
-          metric: {
-            type: 'counter',
-            value: [
-              { labels: {}, value: 9 },
-            ],
-          },
-        },
-      ].to_json,)
+        get '/metrics', nil, headers
+
+        expect(last_response).to be_ok
+        expect(last_response.header['Content-Type']).to eql(format::TYPE)
+        expect(last_response.body).to eql(format.marshal(registry))
+      end
+    end
+
+    context 'when client does send a Accept header' do
+      include_examples 'response', {}, json
+    end
+
+    context 'when client requests application/json' do
+      headers = { 'HTTP_ACCEPT' => json::TYPE }
+
+      include_examples 'response', headers, json
+    end
+
+    context 'when client requests text/plain' do
+      headers = { 'HTTP_ACCEPT' => text::TYPE }
+
+      include_examples 'response', headers, text
+    end
+
+    context 'when client uses different white spaces in Accept header' do
+      headers = { 'HTTP_ACCEPT' => 'text/plain;q=1.0  ; version=0.0.4' }
+
+      include_examples 'response', headers, text
+    end
+
+    context 'when client accepts multiple formats' do
+      headers = { 'HTTP_ACCEPT' => "#{json::TYPE};q=0.5, #{text::TYPE};q=0.7" }
+
+      include_examples 'response', headers, text
+    end
+
+    context 'when client does not include quality attribute' do
+      headers = { 'HTTP_ACCEPT' => "#{json::TYPE};q=0.5, #{text::TYPE}" }
+
+      include_examples 'response', headers, text
+    end
+
+    context 'when client accepts some unknown formats' do
+      headers = { 'HTTP_ACCEPT' => "#{text::TYPE};q=0.3, proto/buf;q=0.7" }
+
+      include_examples 'response', headers, text
+    end
+
+    context 'when client accepts only unknown formats' do
+      headers = { 'HTTP_ACCEPT' => 'fancy/woo;q=0.3, proto/buf;q=0.7' }
+
+      include_examples 'response', headers, json
     end
   end
 end


### PR DESCRIPTION
Missing:
- Use text format in metric exposition if server supports it
- Implement right behavior for summaries as soon as specified
