### PR TITLE
Use `_count` instead of `_total` when exposing summaries

### DIFF
--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -55,7 +55,7 @@ module Prometheus
 
           l = labels(set)
           yield metric("#{name}_sum", l, value.sum)
-          yield metric("#{name}_total", l, value.total)
+          yield metric("#{name}_count", l, value.total)
         end
 
         def self.metric(name, labels, value)

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -66,7 +66,7 @@ qux{for="sake",code="1",quantile="0.5"} 4.2
 qux{for="sake",code="1",quantile="0.9"} 8.32
 qux{for="sake",code="1",quantile="0.99"} 15.3
 qux_sum{for="sake",code="1"} 1243.21
-qux_total{for="sake",code="1"} 93
+qux_count{for="sake",code="1"} 93
       TEXT
     end
   end


### PR DESCRIPTION
@grobie: as per the [exposition format spec](https://docs.google.com/document/d/1ZjyKiKxZV83VI9ZKAXRGKaUKK2BIWCT7oiGBKDBpjEY/edit#), summaries exposed in text format should use the suffix `_count` instead of `_total`:

> The type summary is difficult to represent in the text format. The following conventions apply:
>   - Each quantile x is given as a separate sample, each with a label {quantile="_x_"}.
>   - The sample sum for a summary named x is given as a separate sample named _x\_sum_.
>   - The sample count for a summary named x is given as a separate sample named _x\_count_.