### PR TITLE
Change http_request metric names to match go

### DIFF
--- a/lib/prometheus/client/rack/collector.rb
+++ b/lib/prometheus/client/rack/collector.rb
@@ -39,11 +39,11 @@ module Prometheus
             :http_requests_total,
             'A counter of the total number of HTTP requests made.')
           @requests_duration = @registry.counter(
-            :http_request_durations_total_microseconds,
+            :http_request_duration_total_microseconds,
             'The total amount of time spent answering HTTP requests ' \
             '(microseconds).')
           @durations = @registry.summary(
-            :http_request_durations_microseconds,
+            :http_request_duration_microseconds,
             'A histogram of the response latency (microseconds).')
         end
 

--- a/spec/examples/metric_example.rb
+++ b/spec/examples/metric_example.rb
@@ -12,7 +12,7 @@ shared_examples_for Prometheus::Client::Metric do
       exception = Prometheus::Client::LabelSetValidator::ReservedLabelError
 
       expect do
-        described_class.new(:foo, 'foo docstring',  __name__: 'reserved')
+        described_class.new(:foo, 'foo docstring', __name__: 'reserved')
       end.to raise_exception exception
     end
 

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -4,7 +4,7 @@ require 'prometheus/client/formats/text'
 
 describe Prometheus::Client::Formats::Text do
   let(:summary_value) do
-    { 0.5  => 4.2, 0.9  => 8.32, 0.99 => 15.3 }.tap do |value|
+    { 0.5 => 4.2, 0.9 => 8.32, 0.99 => 15.3 }.tap do |value|
       allow(value).to receive_messages(sum: 1243.21, total: 93)
     end
   end

--- a/spec/prometheus/client/rack/collector_spec.rb
+++ b/spec/prometheus/client/rack/collector_spec.rb
@@ -42,8 +42,8 @@ describe Prometheus::Client::Rack::Collector do
 
     {
       http_requests_total: 1,
-      http_request_durations_total_microseconds: 2,
-      http_request_durations_microseconds: { 0.5 => 2, 0.9 => 2, 0.99 => 2 },
+      http_request_duration_total_microseconds: 2,
+      http_request_duration_microseconds: { 0.5 => 2, 0.9 => 2, 0.99 => 2 },
     }.each do |metric, result|
       expect(registry.get(metric).get(labels)).to eql(result)
     end


### PR DESCRIPTION
I recently used prometheus to monitor web servers in go and ruby/rake that are using the official prometheus client libraries.  I noticed that the go and ruby/rake client libs were using different names for the http metrics:

* go: http_request_duration_microseconds
* ruby/rake: http_request_durations_microseconds

I assumed that the prometheus clients should be using the same metric names.