### PR TITLE
Add possibility to talk HTTPS in push client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,6 @@ Style/TrailingCommaInLiteral:
 
 Metrics/AbcSize:
     Max: 18
+
+Style/GuardClause:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ group :test do
   gem 'rack-test'
   gem 'rake'
   gem 'rspec'
-  gem 'rubocop', ruby_version?('< 2.0') ? '< 0.42' : nil
+  gem 'rubocop', ruby_version?('< 2.0') ? '< 0.42' : '~> 0.45.0'
   gem 'tins', '< 1.7' if ruby_version?('< 2.0')
+  # 1.4+ is not compatible with ruby 1.9
+  gem 'term-ansicolor', '~> 1.3.2'
 end

--- a/lib/prometheus/client/push.rb
+++ b/lib/prometheus/client/push.rb
@@ -16,6 +16,7 @@ module Prometheus
       PATH            = '/metrics/jobs/%s'.freeze
       INSTANCE_PATH   = '/metrics/jobs/%s/instances/%s'.freeze
       HEADER          = { 'Content-Type' => Formats::Text::CONTENT_TYPE }.freeze
+      SUPPORTED_SCHEMES = %w(http https).freeze
 
       attr_reader :job, :instance, :gateway, :path
 
@@ -26,6 +27,7 @@ module Prometheus
         @uri = parse(@gateway)
         @path = build_path(job, instance)
         @http = Net::HTTP.new(@uri.host, @uri.port)
+        @http.use_ssl = @uri.scheme == 'https'
       end
 
       def add(registry)
@@ -45,7 +47,7 @@ module Prometheus
       def parse(url)
         uri = URI.parse(url)
 
-        if uri.scheme == 'http'
+        if SUPPORTED_SCHEMES.include? uri.scheme
           uri
         else
           raise ArgumentError, 'only HTTP gateway URLs are supported currently.'

--- a/spec/prometheus/client/counter_spec.rb
+++ b/spec/prometheus/client/counter_spec.rb
@@ -7,7 +7,7 @@ describe Prometheus::Client::Counter do
   let(:counter) { Prometheus::Client::Counter.new(:foo, 'foo description') }
 
   it_behaves_like Prometheus::Client::Metric do
-    let(:type) { Fixnum }
+    let(:type) { Integer }
   end
 
   describe '#increment' do

--- a/spec/prometheus/client/push_spec.rb
+++ b/spec/prometheus/client/push_spec.rb
@@ -52,7 +52,7 @@ describe Prometheus::Client::Push do
   end
 
   describe '#add' do
-    it 'pushes a given registry to the configured Pushgateway' do
+    it 'pushes a given registry to the configured Pushgateway via HTTP' do
       http = double(:http)
       expect(http).to receive(:send_request).with(
         'POST',
@@ -60,9 +60,24 @@ describe Prometheus::Client::Push do
         Prometheus::Client::Formats::Text.marshal(registry),
         'Content-Type' => Prometheus::Client::Formats::Text::CONTENT_TYPE,
       )
+      expect(http).to receive(:use_ssl=).with(false)
       expect(Net::HTTP).to receive(:new).with('pu.sh', 9091).and_return(http)
 
       described_class.new('foo', 'bar', 'http://pu.sh:9091').add(registry)
+    end
+
+    it 'pushes a given registry to the configured Pushgateway via HTTPS' do
+      http = double(:http)
+      expect(http).to receive(:send_request).with(
+        'POST',
+        '/metrics/jobs/foo/instances/bar',
+        Prometheus::Client::Formats::Text.marshal(registry),
+        'Content-Type' => Prometheus::Client::Formats::Text::CONTENT_TYPE,
+      )
+      expect(http).to receive(:use_ssl=).with(true)
+      expect(Net::HTTP).to receive(:new).with('pu.sh', 9091).and_return(http)
+
+      described_class.new('foo', 'bar', 'https://pu.sh:9091').add(registry)
     end
   end
 
@@ -75,6 +90,7 @@ describe Prometheus::Client::Push do
         Prometheus::Client::Formats::Text.marshal(registry),
         'Content-Type' => Prometheus::Client::Formats::Text::CONTENT_TYPE,
       )
+      expect(http).to receive(:use_ssl=).with(false)
       expect(Net::HTTP).to receive(:new).with('pu.sh', 9091).and_return(http)
 
       described_class.new('foo', 'bar', 'http://pu.sh:9091').replace(registry)
@@ -88,6 +104,7 @@ describe Prometheus::Client::Push do
         'DELETE',
         '/metrics/jobs/foo/instances/bar',
       )
+      expect(http).to receive(:use_ssl=).with(false)
       expect(Net::HTTP).to receive(:new).with('pu.sh', 9091).and_return(http)
 
       described_class.new('foo', 'bar', 'http://pu.sh:9091').delete


### PR DESCRIPTION
Currently, when passing a https URL to the push client, it bails out with an exception. This PR adds the possibility to also use HTTPS instead.