### PR TITLE
Use path normalization in collect label builder example

### DIFF
--- a/examples/rack/README.md
+++ b/examples/rack/README.md
@@ -52,9 +52,10 @@ use Prometheus::Middleware::Collector, counter_label_builder: ->(env, code) {
   {
     code:         code,
     method:       env['REQUEST_METHOD'].downcase,
+    # Include the HTTP Host header as label.
     host:         env['HTTP_HOST'].to_s,
-    path:         env['PATH_INFO'].to_s,
-    http_version: env['HTTP_VERSION'].to_s,
+    # Replace numeric IDs in paths like /users/1234/comments with ':id'.
+    path:         env['PATH_INFO'].to_s.gsub(/\/\d+(\/|$)/, '/:id\\1'),
   }
 }
 ```


### PR DESCRIPTION
@RichiH So I can just point users to that example in the future.