### PR TITLE
Normalize paths including numeric IDs by default

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -39,14 +39,14 @@ module Prometheus
         {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
-          path:   env['PATH_INFO'].to_s,
+          path:   env['PATH_INFO'].gsub(/\/\d+(\/|$)/, '/:id\\1'),
         }
       end
 
       DURATION_LB = proc do |env, _|
         {
           method: env['REQUEST_METHOD'].downcase,
-          path:   env['PATH_INFO'].to_s,
+          path:   env['PATH_INFO'].gsub(/\/\d+(\/|$)/, '/:id\\1'),
         }
       end
 


### PR DESCRIPTION
Quite a few people run into the issue of creating too many time series
by exporting an unbounded number of paths label values. While it's
documented and possible to provide a custom label builder, a better
default is probably to always normalize ids in HTTP paths.

@SuperQ @brian-brazil 