### PR TITLE
Add thread safe increment and decrement operations to gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ gauge.get({ room: 'kitchen' })
 # => 21.534
 ```
 
+Also you can use gauge as the bi-directional counter:
+
+```ruby
+gauge = Prometheus::Client::Gauge.new(:concurrent_requests_total, '...')
+
+gauge.increment({ service: 'foo' })
+# => 1.0
+
+gauge.decrement({ service: 'foo' })
+# => 0.0
+```
+
 ### Histogram
 
 A histogram samples observations (usually things like request durations or

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -19,6 +19,26 @@ module Prometheus
 
         @values[label_set_for(labels)] = value.to_f
       end
+
+      # Increments Gauge value by 1 or adds the given value to the Gauge.
+      # (The value can be negative, resulting in a decrease of the Gauge.)
+      def increment(labels = {}, by = 1)
+        label_set = label_set_for(labels)
+        synchronize do
+          @values[label_set] ||= 0
+          @values[label_set] += by
+        end
+      end
+
+      # Decrements Gauge value by 1 or subtracts the given value from the Gauge.
+      # (The value can be negative, resulting in a increase of the Gauge.)
+      def decrement(labels = {}, by = 1)
+        label_set = label_set_for(labels)
+        synchronize do
+          @values[label_set] ||= 0
+          @values[label_set] -= by
+        end
+      end
     end
   end
 end

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -33,4 +33,84 @@ describe Prometheus::Client::Gauge do
       end
     end
   end
+
+  describe '#increment' do
+    before do
+      gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)
+    end
+
+    it 'increments the gauge' do
+      expect do
+        gauge.increment
+      end.to change { gauge.get }.by(1.0)
+    end
+
+    it 'increments the gauge for a given label set', labels: { test: 'one' } do
+      expect do
+        expect do
+          gauge.increment(test: 'one')
+        end.to change { gauge.get(test: 'one') }.by(1.0)
+      end.to_not change { gauge.get(test: 'another') }
+    end
+
+    it 'increments the gauge by a given value' do
+      expect do
+        gauge.increment({}, 5)
+      end.to change { gauge.get }.by(5.0)
+    end
+
+    it 'returns the new gauge value' do
+      expect(gauge.increment).to eql(1.0)
+    end
+
+    it 'is thread safe' do
+      expect do
+        Array.new(10) do
+          Thread.new do
+            10.times { gauge.increment }
+          end
+        end.each(&:join)
+      end.to change { gauge.get }.by(100.0)
+    end
+  end
+
+  describe '#decrement' do
+    before do
+      gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)
+    end
+
+    it 'increments the gauge' do
+      expect do
+        gauge.decrement
+      end.to change { gauge.get }.by(-1.0)
+    end
+
+    it 'decrements the gauge for a given label set', labels: { test: 'one' } do
+      expect do
+        expect do
+          gauge.decrement(test: 'one')
+        end.to change { gauge.get(test: 'one') }.by(-1.0)
+      end.to_not change { gauge.get(test: 'another') }
+    end
+
+    it 'decrements the gauge by a given value' do
+      expect do
+        gauge.decrement({}, 5)
+      end.to change { gauge.get }.by(-5.0)
+    end
+
+    it 'returns the new gauge value' do
+      expect(gauge.decrement).to eql(-1.0)
+    end
+
+    it 'is thread safe' do
+      expect do
+        Array.new(10) do
+          Thread.new do
+            10.times { gauge.decrement }
+          end
+        end.each(&:join)
+      end.to change { gauge.get }.by(-100.0)
+    end
+  end
 end


### PR DESCRIPTION
Currently, gauges are hard to use as bi-directional counters due to a lack of increment and decrement operations on them.

So I've found myself writing following scary fragments of the code:

```ruby
# Before
simultaneous_service_calls_gauge.send(:synchronize) do
  value = simultaneous_service_calls_gauge.get(tags) || 0
  simultaneous_service_calls_gauge.set(tags, value + 1)
end

simultaneous_service_calls_gauge.send(:synchronize) do
  value = simultaneous_service_calls_gauge.get(tags) || 0
  simultaneous_service_calls_gauge.set(tags, value - 1)
end
```

That's why this PR exists:

```rb
# After
simultaneous_service_calls_gauge.increment(tags)
simultaneous_service_calls_gauge.increment(tags)
```

For now, I've made `increment` and `decrement` to initialize values with `0` before changing (default value of gauge is still `nil`). I've failed to understand the code of python and go client libraries to figure out, whether their gauges have default values or not.

@grobie, can you please take a look?