### PR TITLE
Support Collector middleware using custom metric names

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -25,7 +25,7 @@ module Prometheus
       def initialize(app, options = {})
         @app = app
         @registry = options[:registry] || Client.registry
-        @metrics_prefix = options[:metrics_prefix] || "http_server"
+        @metrics_prefix = options[:metrics_prefix] || 'http_server'
         @counter_lb = options[:counter_label_builder] || COUNTER_LB
         @duration_lb = options[:duration_label_builder] || DURATION_LB
 

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -10,6 +10,9 @@ module Prometheus
     # By default metrics are registered on the global registry. Set the
     # `:registry` option to use a custom registry.
     #
+    # By default metrics all have the prefix "http_server". Set to something
+    # else if you like.
+    #
     # The request counter metric is broken down by code, method and path by
     # default. Set the `:counter_label_builder` option to use a custom label
     # builder.
@@ -22,6 +25,7 @@ module Prometheus
       def initialize(app, options = {})
         @app = app
         @registry = options[:registry] || Client.registry
+        @metrics_prefix = options[:metrics_prefix] || "http_server"
         @counter_lb = options[:counter_label_builder] || COUNTER_LB
         @duration_lb = options[:duration_label_builder] || DURATION_LB
 
@@ -52,18 +56,18 @@ module Prometheus
 
       def init_request_metrics
         @requests = @registry.counter(
-          :http_server_requests_total,
+          :"#{@metrics_prefix}_requests_total",
           'The total number of HTTP requests handled by the Rack application.',
         )
         @durations = @registry.histogram(
-          :http_server_request_duration_seconds,
+          :"#{@metrics_prefix}_request_duration_seconds",
           'The HTTP response duration of the Rack application.',
         )
       end
 
       def init_exception_metrics
         @exceptions = @registry.counter(
-          :http_server_exceptions_total,
+          :"#{@metrics_prefix}_exceptions_total",
           'The total number of exceptions raised by the Rack application.',
         )
       end

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -106,4 +106,32 @@ describe Prometheus::Middleware::Collector do
       expect(registry.get(metric).get(labels)).to eql(1.0)
     end
   end
+
+  context 'when provided a custom metrics_prefix' do
+    let!(:app) do
+      described_class.new(
+        original_app,
+        registry: registry,
+        metrics_prefix: 'lolrus',
+      )
+    end
+
+    it 'provides alternate metric names' do
+      expect(
+        registry.get(:lolrus_requests_total),
+      ).to be_a(Prometheus::Client::Counter)
+      expect(
+        registry.get(:lolrus_request_duration_seconds),
+      ).to be_a(Prometheus::Client::Histogram)
+      expect(
+        registry.get(:lolrus_exceptions_total),
+      ).to be_a(Prometheus::Client::Counter)
+    end
+
+    it "doesn't register the default metrics" do
+      expect(registry.get(:http_server_requests_total)).to be(nil)
+      expect(registry.get(:http_server_request_duration_seconds)).to be(nil)
+      expect(registry.get(:http_server_exceptions_total)).to be(nil)
+    end
+  end
 end


### PR DESCRIPTION
It can sometimes be handy to expose the HTTP server metrics under a
different prefix, either for naming consistency (so all your app metrics
have a common prefix), or to prevent conflicts (it is possible, and
occasionally useful, to run more than one Rack-based webserver in a single
process, although it can be a bit of a wrestle).

Includes tests, which pass on at least 2.3 (things seem spectacularly broken on at least 1.9 and 2.0, for unrelated reasons) and doesn't introduce any new rubocop sadnesses.