### PR TITLE
Normalize UUIDs in request path by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,3 @@ Style/TrailingCommaInLiteral:
 
 Metrics/AbcSize:
     Max: 18
-
-Metrics/BlockLength:
-    Exclude:
-        - 'spec/**/*.rb'

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -39,22 +39,26 @@ module Prometheus
 
       protected
 
+      # rubocop:disable Metrics/LineLength
+      aggregation = lambda do |str|
+        str
+          .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
+          .gsub(%r{/\d+(/|$)}, '/:id\\1')
+      end
+      # rubocop:enable Metrics/LineLength
+
       COUNTER_LB = proc do |env, code|
         {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
-          path:   env['PATH_INFO']
-                    .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
-                    .gsub(%r{/\d+(/|$)}, '/:id\\1'),
+          path:   aggregation.call(env['PATH_INFO']),
         }
       end
 
       DURATION_LB = proc do |env, _|
         {
           method: env['REQUEST_METHOD'].downcase,
-          path:   env['PATH_INFO']
-                    .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
-                    .gsub(%r{/\d+(/|$)}, '/:id\\1'),
+          path:   aggregation.call(env['PATH_INFO']),
         }
       end
 

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -43,14 +43,18 @@ module Prometheus
         {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
-          path:   env['PATH_INFO'].gsub(%r{/\d+(/|$)}, '/:id\\1'),
+          path:   env['PATH_INFO']
+                    .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
+                    .gsub(%r{/\d+(/|$)}, '/:id\\1'),
         }
       end
 
       DURATION_LB = proc do |env, _|
         {
           method: env['REQUEST_METHOD'].downcase,
-          path:   env['PATH_INFO'].gsub(%r{/\d+(/|$)}, '/:id\\1'),
+          path:   env['PATH_INFO']
+                    .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
+                    .gsub(%r{/\d+(/|$)}, '/:id\\1'),
         }
       end
 

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -62,6 +62,20 @@ describe Prometheus::Middleware::Collector do
     expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
   end
 
+  it 'normalizes paths containing UUIDs by default' do
+    expect(Time).to receive(:now).twice.and_return(0.0, 0.3)
+
+    get '/foo/5180349d-a491-4d73-af30-4194a46bdff3/bars'
+
+    metric = :http_server_requests_total
+    labels = { method: 'get', path: '/foo/:uuid/bars', code: '200' }
+    expect(registry.get(metric).get(labels)).to eql(1.0)
+
+    metric = :http_server_request_duration_seconds
+    labels = { method: 'get', path: '/foo/:uuid/bars' }
+    expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
+  end
+
   context 'when the app raises an exception' do
     let(:original_app) do
       lambda do |env|


### PR DESCRIPTION
Hello!

We have a lot of microservices written in ruby, and in our ecosystem (which handles tons of transactions every day) we are using UUID's for our entities. Unfortunately, the Ruby client for Prometheus does not by default normalize UUIDs which required us to get closer to the source code of this gem.

One could argue that this should not be core default behaviour of the gem and that as users we should use the option parameter for `counter_label_builder` and `duration_label_builder` instead. We did that, but it is quite a bother going into each microservice and spreading these local overrides. That's why we put it in a forked version of the client, but ideally we would like it to be part of the library itself.

One last thing to consider, do you believe that UUIDs are growing popular in more and more code bases? I think that is the case, so this would be a positive contribution to the library.