### PR TITLE
Fix threading issue with label_set_for

### DIFF
--- a/lib/prometheus/client/counter.rb
+++ b/lib/prometheus/client/counter.rb
@@ -13,8 +13,10 @@ module Prometheus
       def increment(labels = {}, by = 1)
         raise ArgumentError, 'increment must be a non-negative number' if by < 0
 
-        label_set = label_set_for(labels)
-        synchronize { @values[label_set] += by }
+        synchronize do
+          label_set = label_set_for(labels)
+          @values[label_set] += by
+        end
       end
 
       private

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -23,8 +23,8 @@ module Prometheus
       # Increments Gauge value by 1 or adds the given value to the Gauge.
       # (The value can be negative, resulting in a decrease of the Gauge.)
       def increment(labels = {}, by = 1)
-        label_set = label_set_for(labels)
         synchronize do
+          label_set = label_set_for(labels)
           @values[label_set] ||= 0
           @values[label_set] += by
         end

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -55,8 +55,10 @@ module Prometheus
           raise ArgumentError, 'Label with name "le" is not permitted'
         end
 
-        label_set = label_set_for(labels)
-        synchronize { @values[label_set].observe(value) }
+        synchronize do
+          label_set = label_set_for(labels)
+          @values[label_set].observe(value)
+        end
       end
 
       private

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -30,8 +30,10 @@ module Prometheus
 
       # Records a given value.
       def observe(labels, value)
-        label_set = label_set_for(labels)
-        synchronize { @values[label_set].observe(value) }
+        synchronize do
+          label_set = label_set_for(labels)
+          @values[label_set].observe(value)
+        end
       end
       alias add observe
       deprecate :add, :observe, 2016, 10


### PR DESCRIPTION
This causes an error when parallelized if they're not wrapped together.
Error message: "can't add a new key into a hash during iteration"