### PR TITLE
Add summary for request duration quantiles to the collector

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -71,6 +71,10 @@ module Prometheus
           :"#{@metrics_prefix}_request_duration_seconds",
           'The HTTP response duration of the Rack application.',
         )
+        @summary = @registry.summary(
+          :"#{@metrics_prefix}_request_duration_quantiles",
+          'The HTTP response duration quantiles of the Rack application.',
+        )
       end
 
       def init_exception_metrics
@@ -94,6 +98,7 @@ module Prometheus
       def record(env, code, duration)
         @requests.increment(@counter_lb.call(env, code))
         @durations.observe(@duration_lb.call(env, code), duration)
+        @summary.observe(@duration_lb.call(env, code), duration)
       rescue
         # TODO: log unexpected exception during request recording
         nil

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -46,6 +46,10 @@ describe Prometheus::Middleware::Collector do
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo' }
     expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.25 => 1)
+
+    metric = :http_server_request_duration_quantiles
+    labels = { method: 'get', path: '/foo' }
+    expect(registry.get(metric).get(labels)).to include(0.5 => 0.2, 0.90 => 0.2, 0.99 => 0.2)
   end
 
   it 'normalizes paths containing numeric IDs by default' do
@@ -60,6 +64,10 @@ describe Prometheus::Middleware::Collector do
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:id/bars' }
     expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
+
+    metric = :http_server_request_duration_quantiles
+    labels = { method: 'get', path: '/foo/:id/bars' }
+    expect(registry.get(metric).get(labels)).to include(0.5 => 0.3, 0.90 => 0.3, 0.99 => 0.3)
   end
 
   it 'normalizes paths containing UUIDs by default' do
@@ -74,6 +82,10 @@ describe Prometheus::Middleware::Collector do
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:uuid/bars' }
     expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
+
+    metric = :http_server_request_duration_quantiles
+    labels = { method: 'get', path: '/foo/:uuid/bars' }
+    expect(registry.get(metric).get(labels)).to include(0.5 => 0.3, 0.90 => 0.3, 0.99 => 0.3)
   end
 
   context 'when the app raises an exception' do
@@ -140,12 +152,16 @@ describe Prometheus::Middleware::Collector do
       expect(
         registry.get(:lolrus_exceptions_total),
       ).to be_a(Prometheus::Client::Counter)
+      expect(
+        registry.get(:lolrus_request_duration_quantiles),
+      ).to be_a(Prometheus::Client::Summary)
     end
 
     it "doesn't register the default metrics" do
       expect(registry.get(:http_server_requests_total)).to be(nil)
       expect(registry.get(:http_server_request_duration_seconds)).to be(nil)
       expect(registry.get(:http_server_exceptions_total)).to be(nil)
+      expect(registry.get(:http_server_request_duration_quantiles)).to be(nil)
     end
   end
 end


### PR DESCRIPTION
When setting up monitoring and dashboards for our services we found that we want a convenient way to extract 90 and 99 percentiles for request duration using prometheus primitives without using too much advanced querying on histograms or other indexes.

We think this primitive could be good addition of the basic collector, wdyt?