### PR TITLE
Allow to delete a given set of labels from metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ counter.increment({ service: 'bar' }, 5)
 # get current value for a given label set
 counter.get({ service: 'bar' })
 # => 5
+
+# delete the counter once irrelevant
+counter.delete({ service: 'bar'})
 ```
 
 ### Gauge
@@ -127,6 +130,9 @@ gauge.set({ room: 'kitchen' }, 21.534)
 # retrieve the current value for a given label set
 gauge.get({ room: 'kitchen' })
 # => 21.534
+
+# delete the gauge once irrelevant
+counter.delete({ service: 'bar'})
 ```
 
 Also you can use gauge as the bi-directional counter:

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -30,6 +30,13 @@ module Prometheus
         @values[labels]
       end
 
+      # Deletes the value for the given label set
+      def delete(labels = {})
+        synchronize do
+          @values.delete(labels) if @values.key?(labels)
+        end
+      end
+
       # Returns all label sets with their values
       def values
         synchronize do

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -34,6 +34,18 @@ describe Prometheus::Client::Gauge do
     end
   end
 
+  describe '#delete', labels: { test: 'one' } do
+    before do
+      gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)
+    end
+
+    it 'deletes the gauge for a given label set' do
+      expect do
+        gauge.delete(test: 'one')
+      end.to change { gauge.get(test: 'one') }.from(0).to(nil)
+    end
+  end
+
   describe '#increment' do
     before do
       gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)


### PR DESCRIPTION
This will allow to expose transient metrics. Their existence might
become irrelevant through the application lifecycle.