### PR TITLE
Updated Rack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ require 'rack'
 require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
 
-use Rack::Deflater, if: ->(_, _, _, body) { body.any? && body[0].length > 512 }
+use Rack::Deflater
 use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter
 

--- a/examples/rack/config.ru
+++ b/examples/rack/config.ru
@@ -2,7 +2,7 @@ require 'rack'
 require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
 
-use Rack::Deflater, if: ->(_, _, _, body) { body.any? && body[0].length > 512 }
+use Rack::Deflater
 use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter
 


### PR DESCRIPTION
In newer rack versions the if guard fails with a missing method for
`.any?`. The quickest fix is to remove the guard.