### PR TITLE
Get more precise and reliable duration

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 
+require 'benchmark'
 require 'prometheus/client'
 
 module Prometheus
@@ -81,11 +82,10 @@ module Prometheus
       end
 
       def trace(env)
-        start = Time.now
-        yield.tap do |response|
-          duration = [(Time.now - start).to_f, 0.0].max
-          record(env, response.first.to_s, duration)
-        end
+        response = nil
+        duration = Benchmark.realtime { response = yield }
+        record(env, response.first.to_s, duration)
+        return response
       rescue => exception
         @exceptions.increment(exception: exception.class.name)
         raise

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -35,7 +35,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'traces request information' do
-    expect(Time).to receive(:now).twice.and_return(0.0, 0.2)
+    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.2)
 
     get '/foo'
 
@@ -49,7 +49,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'normalizes paths containing numeric IDs by default' do
-    expect(Time).to receive(:now).twice.and_return(0.0, 0.3)
+    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.3)
 
     get '/foo/42/bars'
 
@@ -63,7 +63,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'normalizes paths containing UUIDs by default' do
-    expect(Time).to receive(:now).twice.and_return(0.0, 0.3)
+    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.3)
 
     get '/foo/5180349d-a491-4d73-af30-4194a46bdff3/bars'
 


### PR DESCRIPTION
`Time.now` method only gives current time. It should be better to use something like `Process.clock_gettime(Process::CLOCK_MONOTONIC)` for runtime measures. @grobie 