### PR TITLE
Extend the invalid signature message

### DIFF
--- a/lib/prometheus/client/label_set_validator.rb
+++ b/lib/prometheus/client/label_set_validator.rb
@@ -35,7 +35,9 @@ module Prometheus
         valid?(labels)
 
         unless @validated.empty? || match?(labels, @validated.first.last)
-          raise InvalidLabelSetError, 'labels must have the same signature'
+          raise InvalidLabelSetError, "labels must have the same signature " \
+                                      "(keys given: #{labels.keys.sort} vs." \
+                                      " keys expected: #{@validated.first.last.keys.sort}"
         end
 
         @validated[labels.hash] = labels

--- a/spec/prometheus/client/label_set_validator_spec.rb
+++ b/spec/prometheus/client/label_set_validator_spec.rb
@@ -63,7 +63,7 @@ describe Prometheus::Client::LabelSetValidator do
 
       expect do
         validator.validate(method: 'get', exception: 'NoMethodError')
-      end.to raise_exception(invalid)
+      end.to raise_exception(invalid, /keys given: \[:exception, :method\] vs. keys expected: \[:code, :method\]/)
     end
   end
 end


### PR DESCRIPTION
I'm new to the whole Prometheus concepts and I often struggle with this error tinkering with labels and base_labels and so on. Testing in irb/pry usually works fine but running a more complex code with "dynamic" labels is somewhat hard to debug, so I made this minor change to help spotting the problem.

@grobie

EDITH: travis failure unrelated to this PR. Coverage decreased due to multiline error message. Should I put this in a single line ? (wasn't sure about your line-length policy)