### PR TITLE
allow setting labels common to all metrics

### DIFF
--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -9,6 +9,12 @@ module Prometheus
     class Metric
       attr_reader :name, :docstring, :base_labels
 
+      @@common_labels = {}
+
+      def self.common_labels=(labels)
+        @@common_labels = labels
+      end
+
       def initialize(name, docstring, base_labels = {})
         @mutex = Mutex.new
         @validator = LabelSetValidator.new
@@ -20,7 +26,7 @@ module Prometheus
 
         @name = name
         @docstring = docstring
-        @base_labels = base_labels
+        @base_labels = @@common_labels.merge(base_labels)
       end
 
       # Returns the value for the given label set

--- a/spec/examples/metric_example.rb
+++ b/spec/examples/metric_example.rb
@@ -43,6 +43,32 @@ shared_examples_for Prometheus::Client::Metric do
     end
   end
 
+  describe 'common_lables' do
+    let(:class_labels) do
+      { foo: :bar }
+    end
+    let(:instance_labels) do
+      { bar: :baz }
+    end
+    before(:each) do
+      described_class.common_labels = class_labels
+    end
+
+    it 'propagates common labels to instance base labels' do
+      m = described_class.new(:name, 'desc', instance_labels)
+      expect(m.base_labels).to eq(class_labels.merge(instance_labels))
+    end
+
+    it 'prefers instance labels over common labels' do
+      instance_labels = class_labels
+      key = class_labels.keys.first
+      instance_labels[:key] = 'different value than in the class labels'
+
+      m = described_class.new(:name, 'desc', instance_labels)
+      expect(m.base_labels[key]).to eq(instance_labels[key])
+    end
+  end
+
   describe '#type' do
     it 'returns the metric type as symbol' do
       expect(subject.type).to be_a(Symbol)


### PR DESCRIPTION
Hi @grobie,

I'd like to be able to have a set of labels common to all metrics. For example a Puma `worker_id` for all Puma services. And obviously I want to avoid setting those labels in constructor of every metric. 

One thing I was wondering about was whether to make it a static hash or a proc, but I didn't come up with a use case for the proc, so it's a hash.

Thanks