### PR TITLE
Abstract Data Storage away from Metric objects, introduce Swappable Data Stores, and support Multiprocess Pre-fork Servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - |
     if [[ "$(ruby -e 'puts RUBY_VERSION')" != 1.* ]]; then gem update --system; fi
 rvm:
-  - 1.9.3
   - 2.3.8
   - 2.4.5
   - 2.5.3

--- a/README.md
+++ b/README.md
@@ -158,15 +158,18 @@ histogram.get(labels: { service: 'users' })
 Summary, similar to histograms, is an accumulator for samples. It captures
 Numeric data and provides an efficient percentile calculation mechanism.
 
+For now, only `sum` and `total` (count of observations) are supported, no actual quantiles.
+
 ```ruby
 summary = Prometheus::Client::Summary.new(:service_latency_seconds, docstring: '...', labels: [:service])
 
 # record a value
 summary.observe(Benchmark.realtime { service.call() }, labels: { service: 'database' })
 
-# retrieve the current quantile values
-summary.get(labels: { service: 'database' })
-# => { 0.5 => 0.1233122, 0.9 => 3.4323, 0.99 => 5.3428231 }
+# retrieve the current sum and total values
+summary_value = summary.get(labels: { service: 'database' })
+summary_value.sum # => 123.45
+summary_value.count # => 100
 ```
 
 ## Labels

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ require 'prometheus/client'
 prometheus = Prometheus::Client.registry
 
 # create a new counter metric
-http_requests = Prometheus::Client::Counter.new(:http_requests, 'A counter of HTTP requests made')
+http_requests = Prometheus::Client::Counter.new(:http_requests, docstring: 'A counter of HTTP requests made')
 # register the metric
 prometheus.register(http_requests)
 
 # equivalent helper function
-http_requests = prometheus.counter(:http_requests, 'A counter of HTTP requests made')
+http_requests = prometheus.counter(:http_requests, docstring: 'A counter of HTTP requests made')
 
 # start using the counter
 http_requests.increment
@@ -99,16 +99,16 @@ The following metric types are currently supported.
 Counter is a metric that exposes merely a sum or tally of things.
 
 ```ruby
-counter = Prometheus::Client::Counter.new(:service_requests_total, '...')
+counter = Prometheus::Client::Counter.new(:service_requests_total, docstring: '...')
 
 # increment the counter for a given label set
-counter.increment({ service: 'foo' })
+counter.increment(labels: { service: 'foo' })
 
 # increment by a given value
-counter.increment({ service: 'bar' }, 5)
+counter.increment(by: 5, labels: { service: 'bar' })
 
 # get current value for a given label set
-counter.get({ service: 'bar' })
+counter.get(labels: { service: 'bar' })
 # => 5
 ```
 
@@ -118,21 +118,21 @@ Gauge is a metric that exposes merely an instantaneous value or some snapshot
 thereof.
 
 ```ruby
-gauge = Prometheus::Client::Gauge.new(:room_temperature_celsius, '...')
+gauge = Prometheus::Client::Gauge.new(:room_temperature_celsius, docstring: '...')
 
 # set a value
-gauge.set({ room: 'kitchen' }, 21.534)
+gauge.set(21.534, labels: { room: 'kitchen' })
 
 # retrieve the current value for a given label set
-gauge.get({ room: 'kitchen' })
+gauge.get(labels: { room: 'kitchen' })
 # => 21.534
 
 # increment the value (default is 1)
-gauge.increment({ room: 'kitchen' })
+gauge.increment(labels: { room: 'kitchen' })
 # => 22.534
 
 # decrement the value by a given value
-gauge.decrement({ room: 'kitchen' }, 5)
+gauge.decrement(by: 5, labels: { room: 'kitchen' })
 # => 17.534
 ```
 
@@ -143,13 +143,13 @@ response sizes) and counts them in configurable buckets. It also provides a sum
 of all observed values.
 
 ```ruby
-histogram = Prometheus::Client::Histogram.new(:service_latency_seconds, '...')
+histogram = Prometheus::Client::Histogram.new(:service_latency_seconds, docstring: '...')
 
 # record a value
-histogram.observe({ service: 'users' }, Benchmark.realtime { service.call(arg) })
+histogram.observe(Benchmark.realtime { service.call(arg) }, labels: { service: 'users' })
 
 # retrieve the current bucket values
-histogram.get({ service: 'users' })
+histogram.get(labels: { service: 'users' })
 # => { 0.005 => 3, 0.01 => 15, 0.025 => 18, ..., 2.5 => 42, 5 => 42, 10 = >42 }
 ```
 
@@ -159,13 +159,13 @@ Summary, similar to histograms, is an accumulator for samples. It captures
 Numeric data and provides an efficient percentile calculation mechanism.
 
 ```ruby
-summary = Prometheus::Client::Summary.new(:service_latency_seconds, '...')
+summary = Prometheus::Client::Summary.new(:service_latency_seconds, docstring: '...')
 
 # record a value
-summary.observe({ service: 'database' }, Benchmark.realtime { service.call() })
+summary.observe(Benchmark.realtime { service.call() }, labels: { service: 'database' })
 
 # retrieve the current quantile values
-summary.get({ service: 'database' })
+summary.get(labels: { service: 'database' })
 # => { 0.5 => 0.1233122, 0.9 => 3.4323, 0.99 => 5.3428231 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,130 @@ https_requests_total.increment(labels: { status_code: response.status_code })
 
 
 
+
+## Data Stores
+
+The data for all the metrics (the internal counters associated with each labelset) 
+is stored in a global Data Store object, rather than in the metric objects themselves.
+(This "storage" is ephemeral, generally in-memory, it's not "long-term storage")
+
+The main reason to do this is that different applications may have different requirements
+for their metrics storage. Application running in pre-fork servers (like Unicorn, for
+example), require a shared store between all the processes, to be able to report coherent
+numbers. At the same time, other applications may not have this requirement but be very
+sensitive to performance, and would prefer instead a simpler, faster store.
+
+By having a standardized and simple interface that metrics use to access this store, 
+we abstract away the details of storing the data from the specific needs of each metric.
+This allows us to then simply swap around the stores based on the needs of different 
+applications, with no changes to the rest of the client. 
+
+The client provides 3 built-in stores, but if neither of these is ideal for your 
+requirements, you can easily make your own store and use that instead. More on this below.
+
+### Configuring which store to use.
+
+By default, the Client uses the `Synchronized` store, which is a simple, thread-safe Store
+for single-process scenarios.
+
+If you need to use a different store, set it in the Client Config:
+
+```ruby
+Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DataStore.new(store_specific_params)
+```
+
+NOTE: You **must** make sure to set the `data_store` before initializing any metrics.
+If using Rails, you probably want to set up your Data Store on `config/application.rb`,
+or `config/environments/*`, both of which run before `config/initializers/*`
+
+Also note that `config.data_store` is set to an *instance* of a `DataStore`, not to the 
+class. This is so that the stores can receive parameters. Most of the built-in stores
+don't require any, but `DirectFileStore` does, for example.
+
+When instantiating metrics, there is an optional `store_settings` attribute. This is used
+to set up store-specific settings for each metric. For most stores, this is not used, but
+for multi-process stores, this is used to specify how to aggregate the values of each
+metric across multiple processes. For the most part, this is used for Gauges, to specify
+whether you want to report the `SUM`, `MAX` or `MIN` value observed across all processes.
+For almost all other cases, you'd leave the default (`SUM`). More on this on the 
+*Aggregation* section below.
+
+Other custom stores may also require or accept extra parameters besides `:aggregation`.
+See the documentation of each store for more details.
+
+### Built-in stores
+
+There are 3 built-in stores, with different trade-offs:
+
+- **Synchronized**: Default store. Thread safe, but not suitable for multi-process 
+  scenarios (e.g. pre-fork servers, like Unicorn). Stores data in Hashes, with all accesses
+  protected by Mutexes. 
+- **SingleThreaded**: Fastest store, but only suitable for single-threaded scenarios.
+  This store does not make any effort to synchronize access to its internal hashes, so 
+  it's absolutely not thread safe.
+- **DirectFileStore**: Stores data in binary files, one file per process and per metric.
+  This is generally the recommended store to use with pre-fork servers and other 
+  "multi-process" scenarios.
+
+  Each metric gets a file for each process, and manages its contents by storing keys and
+  binary floats next to them, and updating the offsets of those Floats directly. When 
+  exporting metrics, it will find all the files that apply to each metric, read them, 
+  and aggregate them.
+
+  In order to do this, each Metric needs an `:aggregation` setting, specifying how
+  to aggregate the multiple possible values we can get for each labelset. By default,
+  they are `SUM`med, which is what most use-cases call for (counters and histograms,
+  for example). However, for Gauges, it's possible to set `MAX` or `MIN` as aggregation, 
+  to get the highest/lowest value of all the processes / threads.
+  
+  Even though this store saves data on disk, it's still much faster than would probably be 
+  expected, because the files are never actually `fsync`ed, so the store never blocks 
+  while waiting for disk. FS caching is incredibly efficient in this regard.
+  
+  If in doubt, check the benchmark scripts described in the documentation for creating 
+  your own stores and run them in your particular runtime environment to make sure this 
+  provides adequate performance.
+
+### Building your own store, and stores other than the built-in ones.
+
+If none of these stores is suitable for your requirements, you can easily make your own.
+
+The interface and requirements of Stores are specified in detail in the `README.md`
+in the `client/data_stores` directory. This thoroughly documents how to make your own 
+store.
+
+There are also links there to non-built-in stores created by others that may be useful,
+either as they are, or as a starting point for making your own.
+
+### Aggregation settings for multi-process stores
+
+If you are in a multi-process environment (such as pre-fork servers like Unicorn), each
+process will probably keep their own counters, which need to be aggregated when receiving
+a Prometheus scrape, to report coherent total numbers.
+
+For Counters and Histograms (and quantile-less Summaries), this is simply a matter of 
+summing the values of each process.
+
+For Gauges, however, this may not be the right thing to do, depending on what they're 
+measuring. You might want to take the maximum or minimum value observed in any process,
+rather than the sum of all of them.
+
+In those cases, you should use the `store_settings` parameter when registering the 
+metric, to specify an `:aggregation` setting. 
+
+```ruby
+free_disk_space = registry.gauge(:free_disk_space_bytes,
+                                docstring: "Free disk space, in bytes",
+                                store_settings: { aggregation: :max })
+```
+
+NOTE: This will only work if the store you're using supports the `:aggregation` setting.
+Of the built-in stores, only `DirectFileStore` does.
+
+Also note that the `:aggregation` setting works for all metric types, not just for gauges. 
+It would be unusual to use it for anything other than gauges, but if your use-case 
+requires it, the store will respect your aggregation wishes.
+
 ## Tests
 
 Install necessary development gems with `bundle install` and run tests with

--- a/examples/rack/README.md
+++ b/examples/rack/README.md
@@ -49,6 +49,8 @@ something like this:
 
 ```ruby
 use Prometheus::Middleware::Collector, counter_label_builder: ->(env, code) {
+  next { code: nil, method: nil, host: nil, path: nil } if env.empty?
+
   {
     code:         code,
     method:       env['REQUEST_METHOD'].downcase,

--- a/lib/prometheus/client.rb
+++ b/lib/prometheus/client.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require 'prometheus/client/registry'
+require 'prometheus/client/config'
 
 module Prometheus
   # Client is a ruby implementation for a Prometheus compatible client.
@@ -8,6 +9,10 @@ module Prometheus
     # Returns a default registry object
     def self.registry
       @registry ||= Registry.new
+    end
+
+    def self.config
+      @config ||= Config.new
     end
   end
 end

--- a/lib/prometheus/client/config.rb
+++ b/lib/prometheus/client/config.rb
@@ -1,0 +1,15 @@
+# encoding: UTF-8
+
+require 'prometheus/client/data_stores/synchronized'
+
+module Prometheus
+  module Client
+    class Config
+      attr_accessor :data_store
+
+      def initialize
+        @data_store = Prometheus::Client::DataStores::Synchronized.new
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/counter.rb
+++ b/lib/prometheus/client/counter.rb
@@ -10,7 +10,7 @@ module Prometheus
         :counter
       end
 
-      def increment(labels = {}, by = 1)
+      def increment(by: 1, labels: {})
         raise ArgumentError, 'increment must be a non-negative number' if by < 0
 
         label_set = label_set_for(labels)

--- a/lib/prometheus/client/counter.rb
+++ b/lib/prometheus/client/counter.rb
@@ -14,13 +14,7 @@ module Prometheus
         raise ArgumentError, 'increment must be a non-negative number' if by < 0
 
         label_set = label_set_for(labels)
-        synchronize { @values[label_set] += by }
-      end
-
-      private
-
-      def default
-        0.0
+        @store.increment(labels: label_set, by: by)
       end
     end
   end

--- a/lib/prometheus/client/data_stores/README.md
+++ b/lib/prometheus/client/data_stores/README.md
@@ -195,11 +195,11 @@ repository for these.
 This is just an example of how one could implement a data store, and a clarification on
 the "aggregation" point 
 
-Important: This is **VAPORWARE**, intended simply to show how this could work / how to
+Important: This is a **toy example**, intended simply to show how this could work / how to
 implement these interfaces.
 
 There are some key pieces of code missing, which are fairly uninteresting, this only shows
-the parts that illustrate the idea of storing multiple different values, and aggregate
+the parts that illustrate the idea of storing multiple different values, and aggregating
 them
 
 ```ruby

--- a/lib/prometheus/client/data_stores/README.md
+++ b/lib/prometheus/client/data_stores/README.md
@@ -1,0 +1,285 @@
+# Custom Data Stores
+
+Stores are basically an abstraction over a Hash, whose keys are in turn a Hash of labels
+plus a metric name. The intention behind having different data stores is solving 
+different requirements for different production scenarios, or performance trade-offs.
+
+The most common of these scenarios are pre-fork servers like Unicorn, which have multiple
+separate processes gathering metrics. If each of these had their own store, the metrics
+reported on each Prometheus scrape would be different, depending on which process handles
+the request. Solving this requires some sort of shared storage between these processes, 
+and there are many ways to solve this problem, each with their own trade-offs.
+
+This abstraction allows us to easily plug in the most adequate store for each scenario.
+
+## Interface
+   
+`Store` exposes a `for_metric` method, which returns a store-specific and metric-specific 
+`MetricStore` object, which represents a "view" onto the actual internal storage for one
+particular metric. Each metric / collector object will have a references to this 
+`MetricStore` and interact with it directly. 
+
+The `MetricStore` class must expose `synchronize`, `set`, `increment`, `get` and `all_values`
+methods,  which are explained in the code sample below. Its initializer should be called 
+only by `Store#for_metric`, not directly.
+
+All values stored are `Float`s.
+
+Internally, a `Store` can store the data however it needs to, based on its requirements. 
+For example, a store that needs to work in a multi-process environment needs to have a 
+shared section of memory, via either Files, an MMap, an external database, or whatever the 
+implementor chooses for their particular use case.
+
+Each `Store` / `MetricStore` will also choose how to divide responsibilities over the 
+storage of values. For some use cases, each `MetricStore` may have their own individual 
+storage, whereas for others, the `Store` may own a central storage, and `MetricStore` 
+objects will access it through the `Store`. This depends on the design choices of each `Store`. 
+
+`Store` and `MetricStore` MUST be thread safe. This applies not only to operations on 
+stored values (`set`, `increment`), but `MetricStore` must also expose a `synchronize`
+method that would allow a Metric to increment multiple values atomically (Histograms need
+this, for example).
+
+Ideally, multiple keys should be modifiable simultaneously, but this is not a
+hard requirement.
+
+This is what the interface looks like, in practice:
+
+```ruby
+module Prometheus
+  module Client
+    module DataStores
+      class CustomStore
+      
+        # Return a MetricStore, which provides a view of the internal data store, 
+        # catering specifically to that metric.
+        #
+        # - `metric_settings` specifies configuration parameters for this metric 
+        #   specifically. These may or may not be necessary, depending on each specific
+        #   store and metric. The most obvious example of this is for gauges in 
+        #   multi-process environments, where the developer needs to choose how those 
+        #   gauges will get aggregated between all the per-process values.
+        # 
+        #   The settings that the store will accept, and what it will do with them, are
+        #   100% Store-specific. Each store should document what settings it will accept
+        #   and how to use them, so the developer using that store can pass the appropriate 
+        #   instantiating the Store itself, and the Metrics they declare.
+        #
+        # - `metric_type` is specified in case a store wants to validate that the settings
+        #   are valid for the metric being set up. It may go unused by most Stores
+        #
+        # Even if your store doesn't need these two parameters, the Store must expose them
+        # to make them swappable.   
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          # Generally, here a Store would validate that the settings passed in are valid,
+          # and raise if they aren't.
+          validate_metric_settings(metric_type: metric_type, 
+                                   metric_settings: metric_settings)
+          MetricStore.new(store: self, 
+                          metric_name: metric_name, 
+                          metric_type: metric_type, 
+                          metric_settings: metric_settings)
+        end
+
+        
+        # MetricStore manages the data for one specific metric. It's generally a view onto
+        # the central store shared by all metrics, but it could also hold the data itself
+        # if that's better for the specific scenario 
+        class MetricStore
+          # This constructor is internal to this store, so the signature doesn't need to
+          # be this. No one other than the Store should be creating MetricStores 
+          def initialize(store:, metric_name:, metric_type:, metric_settings:)
+          end
+
+          # Metrics may need to modify multiple values at once (Histograms do this, for 
+          # example). MetricStore needs to provide a way to synchronize those, in addition
+          # to all of the value modifications being thread-safe without a need for simple 
+          # Metrics to call `synchronize`
+          def synchronize
+            raise NotImplementedError
+          end
+
+          # Store a value for this metric and a set of labels
+          # Internally, may add extra "labels" to disambiguate values between,
+          # for example, different processes
+          def set(labels:, val:)
+            raise NotImplementedError
+          end
+
+          def increment(labels:, by: 1)
+            raise NotImplementedError
+          end
+  
+          # Return a value for a set of labels
+          # Will return the same value stored by `set`, as opposed to `all_values`, which 
+          # may aggregate multiple values.
+          #
+          # For example, in a multi-process scenario, `set` may add an extra internal
+          # label tagging the value with the process id. `get` will return the value for
+          # "this" process ID. `all_values` will return an aggregated value for all 
+          # process IDs.
+          def get(labels:)
+            raise NotImplementedError
+          end
+  
+          # Returns all the sets of labels seen by the Store, and the aggregated value for 
+          # each.
+          # 
+          # In some cases, this is just a matter of returning the stored value.
+          # 
+          # In other cases, the store may need to aggregate multiple values for the same
+          # set of labels. For example, in a multiple process it may need to `sum` the
+          # values of counters from each process. Or for `gauges`, it may need to take the
+          # `max`. This is generally specified in `metric_settings` when calling 
+          # `Store#for_metric`.
+          def all_values
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+## Conventions
+
+- Your store MAY require or accept extra settings for each metric on the call to `for_metric`.
+- You SHOULD validate these parameters to make sure they are correct, and raise if they aren't. 
+- If your store needs to aggregate multiple values for the same metric (for example, in
+  a multi-process scenario), you MUST accept a setting to define how values are aggregated.
+  - This setting MUST be called `:aggregation`
+  - It MUST support, at least, `:sum`, `:max` and `:min`. 
+  - It MAY support other aggregation modes that may apply to your requirements.
+  - It MUST default to `:sum`
+
+## Testing your Store
+
+In order to make it easier to test your store, the basic functionality is tested using
+`shared_examples`:
+
+`it_behaves_like Prometheus::Client::DataStores`
+
+Follow the simple structure in `synchronized_spec.rb` for a starting point.
+
+Note that if your store stores data somewhere other than in-memory (in files, Redis, 
+databases, etc), you will need to do cleanup between tests in a `before` block.
+
+The tests for `DirectFileStore` have a good example at the top of the file. This file also
+has some examples on testing multi-process stores, checking that aggregation between 
+processes works correctly.
+
+## Sample, imaginary multi-process Data Store
+
+This is just an example of how one could implement a data store, and a clarification on
+the "aggregation" point 
+
+Important: This is **VAPORWARE**, intended simply to show how this could work / how to
+implement these interfaces.
+
+There are some key pieces of code missing, which are fairly uninteresting, this only shows
+the parts that illustrate the idea of storing multiple different values, and aggregate
+them
+
+```ruby
+module Prometheus
+  module Client
+    module DataStores
+      # Stores all the data in a magic data structure that keeps cross-process data, in a
+      # way that all processes can read it, but each can write only to their own set of
+      # keys.
+      # It doesn't care how that works, this is not an actual solution to anything,
+      # just an example of how the interface would work with something like that.
+      #
+      # Metric Settings have one possible key, `aggregation`, which must be one of
+      # `AGGREGATION_MODES`
+      class SampleMagicMultiprocessStore
+        AGGREGATION_MODES = [MAX = :max, MIN = :min, SUM = :sum]
+        DEFAULT_METRIC_SETTINGS = { aggregation: SUM }
+
+        def initialize
+          @internal_store = MagicHashSharedBetweenProcesses.new # PStore, for example
+        end
+
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          settings = DEFAULT_METRIC_SETTINGS.merge(metric_settings)
+          validate_metric_settings(metric_settings: settings)
+          MetricStore.new(store: self,
+                          metric_name: metric_name,
+                          metric_type: metric_type,
+                          metric_settings: settings)
+        end
+
+        private
+
+        def validate_metric_settings(metric_settings:)
+          raise unless metric_settings.has_key?(:aggregation)
+          raise unless metric_settings[:aggregation].in?(AGGREGATION_MODES)
+        end
+
+        class MetricStore
+          def initialize(store:, metric_name:, metric_type:, metric_settings:)
+            @store = store
+            @internal_store = store.internal_store
+            @metric_name = metric_name
+            @aggregation_mode = metric_settings[:aggregation]
+          end
+
+          def set(labels:, val:)
+            @internal_store[store_key(labels)] = val.to_f
+          end
+
+          def get(labels:)
+            @internal_store[store_key(labels)]
+          end
+
+          def all_values
+            non_aggregated_values = all_store_values.each_with_object({}) do |(labels, v), acc|
+              if labels["__metric_name"] == @metric_name
+                label_set = labels.reject { |k,_| k.in?("__metric_name", "__pid") }
+                acc[label_set] ||= []
+                acc[label_set] << v
+              end
+            end
+
+            # Aggregate all the different values for each label_set
+            non_aggregated_values.each_with_object({}) do |(label_set, values), acc|
+              acc[label_set] = aggregate(values)
+            end
+          end
+
+          private
+
+          def all_store_values
+            # This assumes there's a something common that all processes can write to, and
+            # it's magically synchronized (which is not true of a PStore, for example, but
+            # would of some sort of external data store like Redis, Memcached, SQLite)
+
+            # This could also have some sort of:
+            #    file_list = Dir.glob(File.join(path, '*.db')).sort
+            # which reads all the PStore files / MMapped files, etc, and returns a hash
+            # with all of them together, which then `values` and `label_sets` can use
+          end
+
+          # This method holds most of the key to how this Store works. Adding `_pid` as
+          # one of the labels, we hold each process's value separately, which we can 
+          # aggregate later 
+          def store_key(labels)
+            labels.merge(
+              {
+                "__metric_name" => @metric_name,
+                "__pid" => Process.pid
+              }
+            )
+          end
+
+          def aggregate(values)
+            # This is a horrible way to do this, just illustrating the point
+            values.send(@aggregation_mode)
+          end
+        end
+      end
+    end
+  end
+end
+```

--- a/lib/prometheus/client/data_stores/README.md
+++ b/lib/prometheus/client/data_stores/README.md
@@ -169,6 +169,27 @@ The tests for `DirectFileStore` have a good example at the top of the file. This
 has some examples on testing multi-process stores, checking that aggregation between 
 processes works correctly.
 
+## Benchmarking your custom data store
+
+If you are developing your own data store, you probably want to benchmark it to see how
+it compares to the built-in ones, and to make sure it achieves the performance you want.
+
+The Prometheus Ruby Client includes some benchmarks (in the `spec/benchmarks` directory)
+to help you with this, and also with validating that your store works correctly.
+
+The `README` in that directory contains more information what these benchmarks are for,
+and how to use them.
+
+## Extra Stores and Research
+
+In the process of abstracting stores away, and creating the built-in ones, GoCardless
+has created a good amount of research, benchmarks, and experimental stores, which 
+weren't useful to include in this repo, but may be a useful resource or starting point 
+if you are building your own store.
+
+Check out the [GoCardless Data Stores Experiments](gocardless/prometheus-client-ruby-data-stores-experiments) 
+repository for these.
+
 ## Sample, imaginary multi-process Data Store
 
 This is just an example of how one could implement a data store, and a clarification on

--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -1,0 +1,313 @@
+require 'concurrent'
+require 'fileutils'
+require "cgi"
+
+module Prometheus
+  module Client
+    module DataStores
+      # Stores data in binary files, one file per process and per metric.
+      # This is generally the recommended store to use to deal with pre-fork servers and
+      # other "multi-process" scenarios.
+      #
+      # Each process will get a file for a metric, and it will manage its contents by
+      # storing keys next to binary-encoded Floats, and keeping track of the offsets of
+      # those Floats, to be able to update them directly as they increase.
+      #
+      # When exporting metrics, the process that gets scraped by Prometheus  will find
+      # all the files that apply to a metric, read their contents, and aggregate them
+      # (generally that means SUMming the values for each labelset).
+      #
+      # In order to do this, each Metric needs an `:aggregation` setting, specifying how
+      # to aggregate the multiple possible values we can get for each labelset. By default,
+      # they are `SUM`med, which is what most use cases call for (counters and histograms,
+      # for example).
+      # However, for Gauges, it's possible to set `MAX` or `MIN` as aggregation, to get
+      # the highest value of all the processes / threads.
+
+      class DirectFileStore
+        class InvalidStoreSettingsError < StandardError; end
+        AGGREGATION_MODES = [MAX = :max, MIN = :min, SUM = :sum]
+        DEFAULT_METRIC_SETTINGS = { aggregation: SUM }
+
+        def initialize(dir:)
+          @store_settings = { dir: dir }
+          FileUtils.mkdir_p(dir)
+        end
+
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          settings = DEFAULT_METRIC_SETTINGS.merge(metric_settings)
+          validate_metric_settings(settings)
+
+          MetricStore.new(metric_name: metric_name,
+                          store_settings: @store_settings,
+                          metric_settings: settings)
+        end
+
+        private
+
+        def validate_metric_settings(metric_settings)
+          unless metric_settings.has_key?(:aggregation) &&
+            AGGREGATION_MODES.include?(metric_settings[:aggregation])
+            raise InvalidStoreSettingsError,
+                  "Metrics need a valid :aggregation key"
+          end
+
+          unless (metric_settings.keys - [:aggregation]).empty?
+            raise InvalidStoreSettingsError,
+                  "Only :aggregation setting can be specified"
+          end
+        end
+
+        class MetricStore
+          attr_reader :metric_name, :store_settings
+
+          def initialize(metric_name:, store_settings:, metric_settings:)
+            @metric_name = metric_name
+            @store_settings = store_settings
+            @values_aggregation_mode = metric_settings[:aggregation]
+
+            @rwlock = Concurrent::ReentrantReadWriteLock.new
+          end
+
+          # Synchronize is used to do a multi-process Mutex, when incrementing multiple
+          # values at once, so that the other process, reading the file for export, doesn't
+          # get incomplete increments.
+          #
+          # `in_process_sync`, instead, is just used so that two threads don't increment
+          # the same value and get a context switch between read and write leading to an
+          # inconsistency
+          def synchronize
+            in_process_sync do
+              internal_store.with_file_lock do
+                yield
+              end
+            end
+          end
+
+          def set(labels:, val:)
+            in_process_sync do
+              internal_store.write_value(store_key(labels), val.to_f)
+            end
+          end
+
+          def increment(labels:, by: 1)
+            key = store_key(labels)
+            in_process_sync do
+              value = internal_store.read_value(key)
+              internal_store.write_value(key, value + by.to_f)
+            end
+          end
+
+          def get(labels:)
+            in_process_sync do
+              internal_store.read_value(store_key(labels))
+            end
+          end
+
+          def all_values
+            stores_data = Hash.new{ |hash, key| hash[key] = [] }
+
+            # There's no need to call `synchronize` here. We're opening a second handle to
+            # the file, and `flock`ing it, which prevents inconsistent reads
+            stores_for_metric.each do |file_path|
+              begin
+                store = FileMappedDict.new(file_path, true)
+                store.all_values.each do |(labelset_qs, v)|
+                  # Labels come as a query string, and CGI::parse returns arrays for each key
+                  # "foo=bar&x=y" => { "foo" => ["bar"], "x" => ["y"] }
+                  # Turn the keys back into symbols, and remove the arrays
+                  label_set = CGI::parse(labelset_qs).map do |k, vs|
+                    [k.to_sym, vs.first]
+                  end.to_h
+
+                  stores_data[label_set] << v
+                end
+              ensure
+                store.close if store
+              end
+            end
+
+            # Aggregate all the different values for each label_set
+            stores_data.each_with_object({}) do |(label_set, values), acc|
+              acc[label_set] = aggregate_values(values)
+            end
+          end
+
+          private
+
+          def in_process_sync
+            @rwlock.with_write_lock { yield }
+          end
+
+          def store_key(labels)
+            labels.map{|k,v| "#{CGI::escape(k.to_s)}=#{CGI::escape(v.to_s)}"}.join('&')
+          end
+
+          def internal_store
+            @internal_store ||= FileMappedDict.new(filemap_filename)
+          end
+
+          # Filename for this metric's PStore (one per process)
+          def filemap_filename
+            filename = "metric_#{ metric_name }___#{ process_id }.bin"
+            File.join(@store_settings[:dir], filename)
+          end
+
+          def stores_for_metric
+            Dir.glob(File.join(@store_settings[:dir], "metric_#{ metric_name }___*"))
+          end
+
+          def process_id
+            Process.pid
+          end
+
+          def aggregate_values(values)
+            if @values_aggregation_mode == SUM
+              values.inject { |sum, element| sum + element }
+            elsif @values_aggregation_mode == MAX
+              values.max
+            elsif @values_aggregation_mode == MIN
+              values.min
+            else
+              raise InvalidStoreSettingsError,
+                    "Invalid Aggregation Mode: #{ @values_aggregation_mode }"
+            end
+          end
+        end
+
+        private_constant :MetricStore
+
+        # A dict of doubles, backed by an file we access directly a a byte array.
+        #
+        # The file starts with a 4 byte int, indicating how much of it is used.
+        # Then 4 bytes of padding.
+        # There's then a number of entries, consisting of a 4 byte int which is the
+        # size of the next field, a utf-8 encoded string key, padding to an 8 byte
+        # alignment, and then a 8 byte float which is the value.
+        class FileMappedDict
+          INITIAL_FILE_SIZE = 1024*1024
+
+          attr_reader :capacity, :used, :positions
+
+          def initialize(filename, readonly = false)
+            @positions = {}
+            @used = 0
+
+            open_file(filename, readonly)
+            @used = @f.read(4).unpack('l')[0] if @capacity > 0
+
+            if @used > 0
+              # File already has data. Read the existing values
+              with_file_lock do
+                read_all_values.each do |key, _, pos|
+                  @positions[key] = pos
+                end
+              end
+            else
+              # File is empty. Init the `used` counter, if we're in write mode
+              if !readonly
+                @used = 8
+                @f.seek(0)
+                @f.write([@used].pack('l'))
+              end
+            end
+          end
+
+          # Yield (key, value, pos). No locking is performed.
+          def all_values
+            with_file_lock do
+              read_all_values.map { |k, v, p| [k, v] }
+            end
+          end
+
+          def read_value(key)
+            if !@positions.has_key?(key)
+              init_value(key)
+            end
+
+            pos = @positions[key]
+            @f.seek(pos)
+            @f.read(8).unpack('d')[0]
+          end
+
+          def write_value(key, value)
+            if !@positions.has_key?(key)
+              init_value(key)
+            end
+
+            pos = @positions[key]
+            @f.seek(pos)
+            @f.write([value].pack('d'))
+            @f.flush
+          end
+
+          def close
+            @f.close
+          end
+
+          def with_file_lock
+            @f.flock(File::LOCK_EX)
+            yield
+          ensure
+            @f.flock(File::LOCK_UN)
+          end
+
+          private
+
+          def open_file(filename, readonly)
+            mode = if readonly
+                     "r"
+                   elsif File.exist?(filename)
+                     "r+b"
+                   else
+                     "w+b"
+                   end
+
+            @f = File.open(filename, mode)
+            if @f.size == 0 && !readonly
+              resize_file(INITIAL_FILE_SIZE)
+            end
+            @capacity = @f.size
+          end
+
+          def resize_file(new_capacity)
+            @f.truncate(new_capacity)
+          end
+
+          # Initialize a value. Lock must be held by caller.
+          def init_value(key)
+            # Pad to be 8-byte aligned.
+            padded = key + (' ' * (8 - (key.length + 4) % 8))
+            value = [padded.length, padded, 0.0].pack("lA#{padded.length}d")
+            while @used + value.length > @capacity
+              @capacity *= 2
+              resize_file(@capacity)
+            end
+            @f.seek(@used)
+            @f.write(value)
+            @used += value.length
+            @f.seek(0)
+            @f.write([@used].pack('l'))
+            @f.flush
+            @positions[key] = @used - 8
+          end
+
+          # Yield (key, value, pos). No locking is performed.
+          def read_all_values
+            @f.seek(8)
+            values = []
+            while @f.pos < @used
+              padded_len = @f.read(4).unpack('l')[0]
+              encoded = @f.read(padded_len).unpack("A#{padded_len}")[0]
+              value = @f.read(8).unpack('d')[0]
+              values << [encoded.strip, value, @f.pos - 8]
+            end
+            values
+          end
+        end
+      end
+    end
+  end
+end
+
+

--- a/lib/prometheus/client/data_stores/single_threaded.rb
+++ b/lib/prometheus/client/data_stores/single_threaded.rb
@@ -1,0 +1,58 @@
+require 'concurrent'
+
+module Prometheus
+  module Client
+    module DataStores
+      # Stores all the data in a simple Hash for each Metric
+      #
+      # Has *no* synchronization primitives, making it the fastest store for single-threaded
+      # scenarios, but must absolutely not be used in multi-threaded scenarios.
+      class SingleThreaded
+        class InvalidStoreSettingsError < StandardError; end
+
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          # We don't need `metric_type` or `metric_settings` for this particular store
+          validate_metric_settings(metric_settings: metric_settings)
+          MetricStore.new
+        end
+
+        private
+
+        def validate_metric_settings(metric_settings:)
+          unless metric_settings.empty?
+            raise InvalidStoreSettingsError,
+                  "SingleThreaded doesn't allow any metric_settings"
+          end
+        end
+
+        class MetricStore
+          def initialize
+            @internal_store = Hash.new { |hash, key| hash[key] = 0.0 }
+          end
+
+          def synchronize
+            yield
+          end
+
+          def set(labels:, val:)
+            @internal_store[labels] = val.to_f
+          end
+
+          def increment(labels:, by: 1)
+            @internal_store[labels] += by
+          end
+
+          def get(labels:)
+            @internal_store[labels]
+          end
+
+          def all_values
+            @internal_store.dup
+          end
+        end
+
+        private_constant :MetricStore
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/data_stores/synchronized.rb
+++ b/lib/prometheus/client/data_stores/synchronized.rb
@@ -1,0 +1,64 @@
+require 'concurrent'
+
+module Prometheus
+  module Client
+    module DataStores
+      # Stores all the data in simple hashes, one per metric. Each of these metrics
+      # synchronizes access to their hash, but multiple metrics can run observations
+      # concurrently.
+      class Synchronized
+        class InvalidStoreSettingsError < StandardError; end
+
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          # We don't need `metric_type` or `metric_settings` for this particular store
+          validate_metric_settings(metric_settings: metric_settings)
+          MetricStore.new
+        end
+
+        private
+
+        def validate_metric_settings(metric_settings:)
+          unless metric_settings.empty?
+            raise InvalidStoreSettingsError,
+                  "Synchronized doesn't allow any metric_settings"
+          end
+        end
+
+        class MetricStore
+          def initialize
+            @internal_store = Hash.new { |hash, key| hash[key] = 0.0 }
+            @rwlock = Concurrent::ReentrantReadWriteLock.new
+          end
+
+          def synchronize
+            @rwlock.with_write_lock { yield }
+          end
+
+          def set(labels:, val:)
+            synchronize do
+              @internal_store[labels] = val.to_f
+            end
+          end
+
+          def increment(labels:, by: 1)
+            synchronize do
+              @internal_store[labels] += by
+            end
+          end
+
+          def get(labels:)
+            synchronize do
+              @internal_store[labels]
+            end
+          end
+
+          def all_values
+            synchronize { @internal_store.dup }
+          end
+        end
+
+        private_constant :MetricStore
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -51,20 +51,20 @@ module Prometheus
 
           def summary(name, set, value)
             l = labels(set)
-            yield metric("#{name}_sum", l, value.sum)
-            yield metric("#{name}_count", l, value.total)
+            yield metric("#{name}_sum", l, value["sum"])
+            yield metric("#{name}_count", l, value["count"])
           end
 
           def histogram(name, set, value)
             bucket = "#{name}_bucket"
             value.each do |q, v|
+              next if q == "sum"
               yield metric(bucket, labels(set.merge(le: q)), v)
             end
-            yield metric(bucket, labels(set.merge(le: '+Inf')), value.total)
 
             l = labels(set)
-            yield metric("#{name}_sum", l, value.sum)
-            yield metric("#{name}_count", l, value.total)
+            yield metric("#{name}_sum", l, value["sum"])
+            yield metric("#{name}_count", l, value["+Inf"])
           end
 
           def metric(name, labels, value)

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -40,14 +40,12 @@ module Prometheus
           private
 
           def representation(metric, label_set, value, &block)
-            set = metric.base_labels.merge(label_set)
-
             if metric.type == :summary
-              summary(metric.name, set, value, &block)
+              summary(metric.name, label_set, value, &block)
             elsif metric.type == :histogram
-              histogram(metric.name, set, value, &block)
+              histogram(metric.name, label_set, value, &block)
             else
-              yield metric(metric.name, labels(set), value)
+              yield metric(metric.name, labels(label_set), value)
             end
           end
 

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -50,10 +50,6 @@ module Prometheus
           end
 
           def summary(name, set, value)
-            value.each do |q, v|
-              yield metric(name, labels(set.merge(quantile: q)), v)
-            end
-
             l = labels(set)
             yield metric("#{name}_sum", l, value.sum)
             yield metric("#{name}_count", l, value.total)

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -17,27 +17,21 @@ module Prometheus
           raise ArgumentError, 'value must be a number'
         end
 
-        @values[label_set_for(labels)] = value.to_f
+        @store.set(labels: label_set_for(labels), val: value)
       end
 
       # Increments Gauge value by 1 or adds the given value to the Gauge.
       # (The value can be negative, resulting in a decrease of the Gauge.)
       def increment(by: 1, labels: {})
         label_set = label_set_for(labels)
-        synchronize do
-          @values[label_set] ||= 0
-          @values[label_set] += by
-        end
+        @store.increment(labels: label_set, by: by)
       end
 
       # Decrements Gauge value by 1 or subtracts the given value from the Gauge.
       # (The value can be negative, resulting in a increase of the Gauge.)
       def decrement(by: 1, labels: {})
         label_set = label_set_for(labels)
-        synchronize do
-          @values[label_set] ||= 0
-          @values[label_set] -= by
-        end
+        @store.increment(labels: label_set, by: -by)
       end
     end
   end

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -12,7 +12,7 @@ module Prometheus
       end
 
       # Sets the value for the given label set
-      def set(labels, value)
+      def set(value, labels: {})
         unless value.is_a?(Numeric)
           raise ArgumentError, 'value must be a number'
         end
@@ -22,7 +22,7 @@ module Prometheus
 
       # Increments Gauge value by 1 or adds the given value to the Gauge.
       # (The value can be negative, resulting in a decrease of the Gauge.)
-      def increment(labels = {}, by = 1)
+      def increment(by: 1, labels: {})
         label_set = label_set_for(labels)
         synchronize do
           @values[label_set] ||= 0
@@ -32,7 +32,7 @@ module Prometheus
 
       # Decrements Gauge value by 1 or subtracts the given value from the Gauge.
       # (The value can be negative, resulting in a increase of the Gauge.)
-      def decrement(labels = {}, by = 1)
+      def decrement(by: 1, labels: {})
         label_set = label_set_for(labels)
         synchronize do
           @values[label_set] ||= 0

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -8,48 +8,29 @@ module Prometheus
     # or response sizes) and counts them in configurable buckets. It also
     # provides a sum of all observed values.
     class Histogram < Metric
-      # Value represents the state of a Histogram at a given point.
-      class Value < Hash
-        attr_accessor :sum, :total
-
-        def initialize(buckets:)
-          @sum = 0.0
-          @total = 0.0
-
-          buckets.each do |bucket|
-            self[bucket] = 0.0
-          end
-        end
-
-        def observe(value)
-          @sum += value
-          @total += 1
-
-          each_key do |bucket|
-            self[bucket] += 1 if value <= bucket
-          end
-        end
-      end
-
       # DEFAULT_BUCKETS are the default Histogram buckets. The default buckets
       # are tailored to broadly measure the response time (in seconds) of a
       # network service. (From DefBuckets client_golang)
       DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
                          2.5, 5, 10].freeze
 
+      attr_reader :buckets
+
       # Offer a way to manually specify buckets
       def initialize(name,
                      docstring:,
                      labels: [],
                      preset_labels: {},
-                     buckets: DEFAULT_BUCKETS)
-        raise ArgumentError, 'Unsorted buckets, typo?' unless sorted? buckets
+                     buckets: DEFAULT_BUCKETS,
+                     store_settings: {})
+        raise ArgumentError, 'Unsorted buckets, typo?' unless sorted?(buckets)
 
         @buckets = buckets
         super(name,
               docstring: docstring,
               labels: labels,
-              preset_labels: preset_labels)
+              preset_labels: preset_labels,
+              store_settings: store_settings)
       end
 
       def type
@@ -57,18 +38,48 @@ module Prometheus
       end
 
       def observe(value, labels: {})
-        label_set = label_set_for(labels)
-        synchronize { @values[label_set].observe(value) }
+        base_label_set = label_set_for(labels)
+
+        @store.synchronize do
+          buckets.each do |upper_limit|
+            next if value > upper_limit
+            @store.increment(labels: base_label_set.merge(le: upper_limit), by: 1)
+          end
+          @store.increment(labels: base_label_set.merge(le: "+Inf"), by: 1)
+          @store.increment(labels: base_label_set.merge(le: "sum"), by: value)
+        end
+      end
+
+      # Returns a hash with all the buckets plus +Inf (count) plus Sum for the given label set
+      def get(labels: {})
+        base_label_set = label_set_for(labels)
+
+        all_buckets = buckets + ["+Inf", "sum"]
+
+        @store.synchronize do
+          all_buckets.each_with_object({}) do |upper_limit, acc|
+            acc[upper_limit] = @store.get(labels: base_label_set.merge(le: upper_limit))
+          end.tap do |acc|
+            acc["count"] = acc["+Inf"]
+          end
+        end
+      end
+
+      # Returns all label sets with their values expressed as hashes with their buckets
+      def values
+        v = @store.all_values
+
+        v.each_with_object({}) do |(label_set, v), acc|
+          actual_label_set = label_set.reject{|l| l == :le }
+          acc[actual_label_set] ||= @buckets.map{|b| [b, 0.0]}.to_h
+          acc[actual_label_set][label_set[:le]] = v
+        end
       end
 
       private
 
       def reserved_labels
         [:le]
-      end
-
-      def default
-        Value.new(buckets: @buckets)
       end
 
       def sorted?(bucket)

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -38,11 +38,18 @@ module Prometheus
                          2.5, 5, 10].freeze
 
       # Offer a way to manually specify buckets
-      def initialize(name, docstring:, base_labels: {}, buckets: DEFAULT_BUCKETS)
+      def initialize(name,
+                     docstring:,
+                     labels: [],
+                     preset_labels: {},
+                     buckets: DEFAULT_BUCKETS)
         raise ArgumentError, 'Unsorted buckets, typo?' unless sorted? buckets
 
         @buckets = buckets
-        super(name, docstring: docstring, base_labels: base_labels)
+        super(name,
+              docstring: docstring,
+              labels: labels,
+              preset_labels: preset_labels)
       end
 
       def type
@@ -50,15 +57,15 @@ module Prometheus
       end
 
       def observe(value, labels: {})
-        if labels[:le]
-          raise ArgumentError, 'Label with name "le" is not permitted'
-        end
-
         label_set = label_set_for(labels)
         synchronize { @values[label_set].observe(value) }
       end
 
       private
+
+      def reserved_labels
+        [:le]
+      end
 
       def default
         Value.new(buckets: @buckets)

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -58,7 +58,7 @@ module Prometheus
 
         @store.synchronize do
           all_buckets.each_with_object({}) do |upper_limit, acc|
-            acc[upper_limit] = @store.get(labels: base_label_set.merge(le: upper_limit))
+            acc[upper_limit.to_s] = @store.get(labels: base_label_set.merge(le: upper_limit))
           end.tap do |acc|
             acc["count"] = acc["+Inf"]
           end
@@ -71,8 +71,8 @@ module Prometheus
 
         v.each_with_object({}) do |(label_set, v), acc|
           actual_label_set = label_set.reject{|l| l == :le }
-          acc[actual_label_set] ||= @buckets.map{|b| [b, 0.0]}.to_h
-          acc[actual_label_set][label_set[:le]] = v
+          acc[actual_label_set] ||= @buckets.map{|b| [b.to_s, 0.0]}.to_h
+          acc[actual_label_set][label_set[:le].to_s] = v
         end
       end
 

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -12,7 +12,7 @@ module Prometheus
       class Value < Hash
         attr_accessor :sum, :total
 
-        def initialize(buckets)
+        def initialize(buckets:)
           @sum = 0.0
           @total = 0.0
 
@@ -38,19 +38,18 @@ module Prometheus
                          2.5, 5, 10].freeze
 
       # Offer a way to manually specify buckets
-      def initialize(name, docstring, base_labels = {},
-                     buckets = DEFAULT_BUCKETS)
+      def initialize(name, docstring:, base_labels: {}, buckets: DEFAULT_BUCKETS)
         raise ArgumentError, 'Unsorted buckets, typo?' unless sorted? buckets
 
         @buckets = buckets
-        super(name, docstring, base_labels)
+        super(name, docstring: docstring, base_labels: base_labels)
       end
 
       def type
         :histogram
       end
 
-      def observe(labels, value)
+      def observe(value, labels: {})
         if labels[:le]
           raise ArgumentError, 'Label with name "le" is not permitted'
         end
@@ -62,7 +61,7 @@ module Prometheus
       private
 
       def default
-        Value.new(@buckets)
+        Value.new(buckets: @buckets)
       end
 
       def sorted?(bucket)

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -33,6 +33,15 @@ module Prometheus
               store_settings: store_settings)
       end
 
+      def with_labels(labels)
+        self.class.new(name,
+                       docstring: docstring,
+                       labels: @labels,
+                       preset_labels: preset_labels.merge(labels),
+                       buckets: @buckets,
+                       store_settings: @store_settings)
+      end
+
       def type
         :histogram
       end

--- a/lib/prometheus/client/label_set_validator.rb
+++ b/lib/prometheus/client/label_set_validator.rb
@@ -21,7 +21,7 @@ module Prometheus
         @validated = {}
       end
 
-      def valid?(labels)
+      def validate_symbols!(labels)
         unless labels.respond_to?(:all?)
           raise InvalidLabelSetError, "#{labels} is not a valid label set"
         end
@@ -33,24 +33,24 @@ module Prometheus
         end
       end
 
-      def validate(labels)
-        return labels if @validated.key?(labels.hash)
+      def validate_labelset!(labelset)
+        return labelset if @validated.key?(labelset.hash)
 
-        valid?(labels)
+        validate_symbols!(labelset)
 
-        unless keys_match?(labels)
+        unless keys_match?(labelset)
           raise InvalidLabelSetError, "labels must have the same signature " \
-                                      "(keys given: #{labels.keys.sort} vs." \
+                                      "(keys given: #{labelset.keys.sort} vs." \
                                       " keys expected: #{expected_labels}"
         end
 
-        @validated[labels.hash] = labels
+        @validated[labelset.hash] = labelset
       end
 
       private
 
-      def keys_match?(labels)
-        labels.keys.sort == expected_labels
+      def keys_match?(labelset)
+        labelset.keys.sort == expected_labels
       end
 
       def validate_symbol(key)

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -34,6 +34,11 @@ module Prometheus
           metric_type: type,
           metric_settings: store_settings
         )
+
+        if preset_labels.keys.length == labels.length
+          @validator.validate(preset_labels)
+          @all_labels_preset = true
+        end
       end
 
       # Returns the value for the given label set
@@ -78,6 +83,8 @@ module Prometheus
       end
 
       def label_set_for(labels)
+        # We've already validated, and there's nothing to merge. Save some cycles
+        return preset_labels if @all_labels_preset && labels.empty?
         @validator.validate(preset_labels.merge(labels))
       end
     end

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -22,6 +22,9 @@ module Prometheus
         @validator.valid?(labels)
         @validator.valid?(preset_labels)
 
+        @labels = labels
+        @store_settings = store_settings
+
         @name = name
         @docstring = docstring
         @preset_labels = preset_labels
@@ -37,6 +40,14 @@ module Prometheus
       def get(labels: {})
         label_set = label_set_for(labels)
         @store.get(labels: label_set)
+      end
+
+      def with_labels(labels)
+        self.class.new(name,
+                       docstring: docstring,
+                       labels: @labels,
+                       preset_labels: preset_labels.merge(labels),
+                       store_settings: @store_settings)
       end
 
       # Returns all label sets with their values

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -19,8 +19,8 @@ module Prometheus
         validate_docstring(docstring)
         @validator = LabelSetValidator.new(expected_labels: labels,
                                            reserved_labels: reserved_labels)
-        @validator.valid?(labels)
-        @validator.valid?(preset_labels)
+        @validator.validate_symbols!(labels)
+        @validator.validate_symbols!(preset_labels)
 
         @labels = labels
         @store_settings = store_settings
@@ -36,7 +36,7 @@ module Prometheus
         )
 
         if preset_labels.keys.length == labels.length
-          @validator.validate(preset_labels)
+          @validator.validate_labelset!(preset_labels)
           @all_labels_preset = true
         end
       end
@@ -85,7 +85,7 @@ module Prometheus
       def label_set_for(labels)
         # We've already validated, and there's nothing to merge. Save some cycles
         return preset_labels if @all_labels_preset && labels.empty?
-        @validator.validate(preset_labels.merge(labels))
+        @validator.validate_labelset!(preset_labels.merge(labels))
       end
     end
   end

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -9,7 +9,7 @@ module Prometheus
     class Metric
       attr_reader :name, :docstring, :base_labels
 
-      def initialize(name, docstring, base_labels = {})
+      def initialize(name, docstring:, base_labels: {})
         @mutex = Mutex.new
         @validator = LabelSetValidator.new
         @values = Hash.new { |hash, key| hash[key] = default }
@@ -24,7 +24,7 @@ module Prometheus
       end
 
       # Returns the value for the given label set
-      def get(labels = {})
+      def get(labels: {})
         @validator.valid?(labels)
 
         @values[labels]

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,21 +37,24 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring, base_labels = {})
-        register(Counter.new(name, docstring, base_labels))
+      def counter(name, docstring:, base_labels: {})
+        register(Counter.new(name, docstring: docstring, base_labels: base_labels))
       end
 
-      def summary(name, docstring, base_labels = {})
-        register(Summary.new(name, docstring, base_labels))
+      def summary(name, docstring:, base_labels: {})
+        register(Summary.new(name, docstring: docstring, base_labels: base_labels))
       end
 
-      def gauge(name, docstring, base_labels = {})
-        register(Gauge.new(name, docstring, base_labels))
+      def gauge(name, docstring:, base_labels: {})
+        register(Gauge.new(name, docstring: docstring, base_labels: base_labels))
       end
 
-      def histogram(name, docstring, base_labels = {},
-                    buckets = Histogram::DEFAULT_BUCKETS)
-        register(Histogram.new(name, docstring, base_labels, buckets))
+      def histogram(name, docstring:, base_labels: {},
+                    buckets: Histogram::DEFAULT_BUCKETS)
+        register(Histogram.new(name,
+                               docstring: docstring,
+                               base_labels: base_labels,
+                               buckets: buckets))
       end
 
       def exist?(name)

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,23 +37,33 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring:, base_labels: {})
-        register(Counter.new(name, docstring: docstring, base_labels: base_labels))
+      def counter(name, docstring:, labels: [], preset_labels: {})
+        register(Counter.new(name,
+                             docstring: docstring,
+                             labels: labels,
+                             preset_labels: preset_labels))
       end
 
-      def summary(name, docstring:, base_labels: {})
-        register(Summary.new(name, docstring: docstring, base_labels: base_labels))
+      def summary(name, docstring:, labels: [], preset_labels: {})
+        register(Summary.new(name,
+                             docstring: docstring,
+                             labels: labels,
+                             preset_labels: preset_labels))
       end
 
-      def gauge(name, docstring:, base_labels: {})
-        register(Gauge.new(name, docstring: docstring, base_labels: base_labels))
+      def gauge(name, docstring:, labels: [], preset_labels: {})
+        register(Gauge.new(name,
+                           docstring: docstring,
+                           labels: labels,
+                           preset_labels: preset_labels))
       end
 
-      def histogram(name, docstring:, base_labels: {},
+      def histogram(name, docstring:, labels: [], preset_labels: {},
                     buckets: Histogram::DEFAULT_BUCKETS)
         register(Histogram.new(name,
                                docstring: docstring,
-                               base_labels: base_labels,
+                               labels: labels,
+                               preset_labels: preset_labels,
                                buckets: buckets))
       end
 

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,34 +37,39 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring:, labels: [], preset_labels: {})
+      def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Counter.new(name,
                              docstring: docstring,
                              labels: labels,
-                             preset_labels: preset_labels))
+                             preset_labels: preset_labels,
+                             store_settings: {}))
       end
 
-      def summary(name, docstring:, labels: [], preset_labels: {})
+      def summary(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Summary.new(name,
                              docstring: docstring,
                              labels: labels,
-                             preset_labels: preset_labels))
+                             preset_labels: preset_labels,
+                             store_settings: {}))
       end
 
-      def gauge(name, docstring:, labels: [], preset_labels: {})
+      def gauge(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Gauge.new(name,
                            docstring: docstring,
                            labels: labels,
-                           preset_labels: preset_labels))
+                           preset_labels: preset_labels,
+                           store_settings: {}))
       end
 
       def histogram(name, docstring:, labels: [], preset_labels: {},
-                    buckets: Histogram::DEFAULT_BUCKETS)
+                    buckets: Histogram::DEFAULT_BUCKETS,
+                    store_settings: {})
         register(Histogram.new(name,
                                docstring: docstring,
                                labels: labels,
                                preset_labels: preset_labels,
-                               buckets: buckets))
+                               buckets: buckets,
+                               store_settings: {}))
       end
 
       def exist?(name)

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -52,6 +52,10 @@ module Prometheus
 
       private
 
+      def reserved_labels
+        [:quantile]
+      end
+
       def default
         Quantile::Estimator.new
       end

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -12,7 +12,7 @@ module Prometheus
       class Value < Hash
         attr_accessor :sum, :total
 
-        def initialize(estimator)
+        def initialize(estimator:)
           @sum = estimator.sum
           @total = estimator.observations
 
@@ -27,17 +27,17 @@ module Prometheus
       end
 
       # Records a given value.
-      def observe(labels, value)
+      def observe(value, labels: {})
         label_set = label_set_for(labels)
         synchronize { @values[label_set].observe(value) }
       end
 
       # Returns the value for the given label set
-      def get(labels = {})
+      def get(labels: {})
         @validator.valid?(labels)
 
         synchronize do
-          Value.new(@values[labels])
+          Value.new(estimator: @values[labels])
         end
       end
 
@@ -45,7 +45,7 @@ module Prometheus
       def values
         synchronize do
           @values.each_with_object({}) do |(labels, value), memo|
-            memo[labels] = Value.new(value)
+            memo[labels] = Value.new(estimator: value)
           end
         end
       end

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -8,8 +8,6 @@ module Prometheus
     # Summary is an accumulator for samples. It captures Numeric data and
     # provides an efficient quantile calculation mechanism.
     class Summary < Metric
-      extend Gem::Deprecate
-
       # Value represents the state of a Summary at a given point.
       class Value < Hash
         attr_accessor :sum, :total
@@ -33,8 +31,6 @@ module Prometheus
         label_set = label_set_for(labels)
         synchronize { @values[label_set].observe(value) }
       end
-      alias add observe
-      deprecate :add, :observe, 2016, 10
 
       # Returns the value for the given label set
       def get(labels = {})

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -7,39 +7,48 @@ module Prometheus
     # Summary is an accumulator for samples. It captures Numeric data and
     # provides the total count and sum of observations.
     class Summary < Metric
-      # Value represents the state of a Summary at a given point.
-      class Value
-        attr_accessor :sum, :total
-
-        def initialize
-          @sum = 0.0
-          @total = 0.0
-        end
-
-        def observe(value)
-          @sum += value
-          @total += 1
-        end
-      end
-
       def type
         :summary
       end
 
       # Records a given value.
       def observe(value, labels: {})
-        label_set = label_set_for(labels)
-        synchronize { @values[label_set].observe(value) }
+        base_label_set = label_set_for(labels)
+
+        @store.synchronize do
+          @store.increment(labels: base_label_set.merge(quantile: "count"), by: 1)
+          @store.increment(labels: base_label_set.merge(quantile: "sum"), by: value)
+        end
+      end
+
+      # Returns a hash with "sum" and "count" as keys
+      def get(labels: {})
+        base_label_set = label_set_for(labels)
+
+        internal_counters = ["count", "sum"]
+
+        @store.synchronize do
+          internal_counters.each_with_object({}) do |counter, acc|
+            acc[counter] = @store.get(labels: base_label_set.merge(quantile: counter))
+          end
+        end
+      end
+
+      # Returns all label sets with their values expressed as hashes with their sum/count
+      def values
+        v = @store.all_values
+
+        v.each_with_object({}) do |(label_set, v), acc|
+          actual_label_set = label_set.reject{|l| l == :quantile }
+          acc[actual_label_set] ||= { "count" => 0.0, "sum" => 0.0 }
+          acc[actual_label_set][label_set[:quantile]] = v
+        end
       end
 
       private
 
       def reserved_labels
         [:quantile]
-      end
-
-      def default
-        Value.new
       end
     end
   end

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -20,6 +20,11 @@ module Prometheus
     #
     # The request duration metric is broken down by method and path by default.
     # Set the `:duration_label_builder` option to use a custom label builder.
+    #
+    # Label Builder functions will receive a Rack env and a status code, and must
+    # return a hash with the labels for that request. They must also accept an empty
+    # env, and return a hash with the correct keys. This is necessary to initialize
+    # the metrics with the correct set of labels.
     class Collector
       attr_reader :app, :registry
 
@@ -47,6 +52,8 @@ module Prometheus
       end
 
       COUNTER_LB = proc do |env, code|
+        next { code: nil, method: nil, path: nil } if env.empty?
+
         {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
@@ -55,6 +62,8 @@ module Prometheus
       end
 
       DURATION_LB = proc do |env, _|
+        next { method: nil, path: nil } if env.empty?
+
         {
           method: env['REQUEST_METHOD'].downcase,
           path:   aggregation.call(env['PATH_INFO']),
@@ -66,10 +75,12 @@ module Prometheus
           :"#{@metrics_prefix}_requests_total",
           docstring:
             'The total number of HTTP requests handled by the Rack application.',
+          labels: @counter_lb.call({}, "").keys
         )
         @durations = @registry.histogram(
           :"#{@metrics_prefix}_request_duration_seconds",
           docstring: 'The HTTP response duration of the Rack application.',
+          labels: @duration_lb.call({}, "").keys
         )
       end
 
@@ -77,6 +88,7 @@ module Prometheus
         @exceptions = @registry.counter(
           :"#{@metrics_prefix}_exceptions_total",
           docstring: 'The total number of exceptions raised by the Rack application.',
+          labels: [:exception]
         )
       end
 

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |s|
 
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
+
+  s.add_dependency 'concurrent-ruby'
 end

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths     = ['lib']
 
   s.add_dependency 'concurrent-ruby'
+
+  s.add_development_dependency 'benchmark-ips'
 end

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -14,6 +14,4 @@ Gem::Specification.new do |s|
 
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
-
-  s.add_dependency 'quantile', '~> 0.2.1'
 end

--- a/spec/benchmarks/README.md
+++ b/spec/benchmarks/README.md
@@ -1,0 +1,67 @@
+# Performance Benchmarks
+
+The intention behind these benchmarks is twofold:
+
+- On the one hand, if you have performance concerns for your counters, they'll allow you
+  to simulate a reasonably realistic scenario, with your particular runtime characteristics,
+  so you can know what kind of performance to expect under different circumstances, and pick
+  settings accordingly.
+
+- On the other hand, if you are developing your own Custom Data Store (more on this in
+  `/lib/prometheus/client/data_stores/README.md), this will allow you to test how it 
+  performs compared to the built-in ones, and also "system test" it to validate that it
+  behaves appropriately.
+  
+## Benchmarks included
+
+### Data Stores Performance
+
+The Prometheus Ruby Client ships with different built-in data stores, optimized for 
+different common scenarios (more on this on the repo's main README, under `Data Stores`).
+
+This benchmark can show you, for your particular runtime environment, what kind of 
+performance you can expect from each, to pick the one that's best for you.
+
+More importantly, in a case where the built-in stores may not be useful for your 
+particular circumstances, you might want to make your own Data Store. If that is the case,
+this benchmark will help you compare its performance characteristics to the built-in 
+stores, and will also run an export after the observations are made, and compare it with
+the built-in ones, helping you catch potential bugs in your store, if the output doesn't
+match.
+
+The benchmark was made to try and simulate a somewhat realistic scenario, with plenty of
+high-cardinality metrics, which is what you should be aiming for. It has a balance of 
+counters and histograms, different label counts for different metrics, different thread
+counts, etc. All this should be easy to customize to your particular needs by modifying 
+the constants in the benchmark to tailor to what you need to measure.
+
+In particular, if going for the goal of "how long it should take to increment a counter",
+you probably want to have no labels and no histograms, since that's the reference 
+performance measurement we use. 
+
+### Labels Performance
+
+Adding labels to your metrics can have significant performance impact, on two fronts:
+
+- Labels passed in on every observation need to be validated. This may be alleviated by 
+  using `with_labels`. If used to pre-set *all* labels, you can save a good
+  amount of processing time, by skipping validation on each observation. This may be 
+  important if you're incrementing metrics on a tight loop, and this benchmark can help
+  with establishing what's to be expected.
+  
+- Even when caching them, these labels are keys to Hashes, they need to sometimes be 
+  serialized into strings, sometimes merged into other hashes. All this incurs performance
+  costs. This benchmark will allow you to estimate how much impact they can have. Again,
+  if incrementing metrics on a tight loop, this will let you estimate whether you might
+  want to have fewer labels instead.
+  
+It should be easy to modify the constants in this benchmark to your particular situation,
+if necessary.
+
+## Running the benchmarks
+
+Simply run, from the repo's root directory:
+
+`bundle exec ruby spec/benchmarks/labels.rb`
+`bundle exec ruby spec/benchmarks/data_stores.rb`
+

--- a/spec/benchmarks/data_stores.rb
+++ b/spec/benchmarks/data_stores.rb
@@ -1,0 +1,329 @@
+require 'benchmark'
+require 'prometheus/client'
+require 'prometheus/client/counter'
+require 'prometheus/client/histogram'
+require 'prometheus/client/formats/text'
+require 'prometheus/client/data_stores/single_threaded'
+require 'prometheus/client/data_stores/synchronized'
+require 'prometheus/client/data_stores/direct_file_store'
+
+# Compare the time it takes different stores to observe a large number of data points, in
+# a multi-threaded environment.
+#
+# If you create a new store and want to benchmark it, add it to the `STORES` array,
+# and run the benchmark to see how it compares to the other options.
+#
+# Each test instantiates a number of Histograms and Counters, with a random number of
+# labels, instantiates a number of threads, and then prepares a a large number of
+# observations, which it distributes randomly between the different metrics and threads
+# created.
+#
+# It does this for each of the STORES specified and different THREAD_COUNTS, then once
+# all that is ready, it starts the benchmark test and lets the threads run to observe
+# those data points.
+#
+# In addition to timing the observation of data points, the benchmark also runs the Text
+# Exporter on the results, and compares them between stores to make sure all stores
+# result in the same output being generated. If this output doesn't match exactly,
+# something is going wrong, and it probably indicates a bug in the store, so this
+# benchmark also acts as a sort of system test for stores. If a mismatch is found, a
+# WARNING will show up in the output, and both the expected and actual results will be
+# dumped to text files, for help in debugging.
+#
+# Data generation involves randomness, but the RNG is seeded so that different stores are
+# exposed to the same pattern of access (as long as two test cases have the same number
+# of threads), reducing the effects on the result of randomness in lock contention.
+#
+# NOTE: If you leave the default of 1_000_000 DATA_POINTS, then the timing result is
+# showing "microseconds per observation", which is the unit we care about.
+# We're aiming for 1 microsecond per observation, which is not quite achievable in Ruby,
+# but that's what we're trying to approach. If you're trying to compare against this
+# goal, set NUM_HISTOGRAMS and MAX_LABELS to 0, for a fair comparison, as both labels
+# and histograms are much slower than label-less counters.
+#-----------------------------------------------------------------------------------
+
+# Store class that follows the required interface but does nothing. Used as a baseline
+# of how much time is spent outside the store.
+class NoopStore
+  def for_metric(metric_name, metric_type:, metric_settings: {})
+    MetricStore.new
+  end
+
+  class MetricStore
+    def synchronize
+      yield
+    end
+
+    def set(labels:, val:); end
+    def increment(labels:, by: 1); end
+    def get(labels:); end
+    def all_values; {}; end
+  end
+end
+
+#-----------------------------------------------------------------------------------
+
+RANDOM_SEED = 12345678
+NUM_COUNTERS = 80
+NUM_HISTOGRAMS = 20
+DATA_POINTS = 1_000_000
+MIN_LABELS = 0
+MAX_LABELS = 4
+THREAD_COUNTS = [1, 2, 4, 8, 12, 16, 20]
+
+TMP_DIR = "/tmp/prometheus_benchmark"
+
+STORES = [
+  { store: NoopStore.new },
+  { store: Prometheus::Client::DataStores::SingleThreaded.new, max_threads: 1 },
+  { store: Prometheus::Client::DataStores::Synchronized.new },
+  {
+    store: Prometheus::Client::DataStores::DirectFileStore.new(dir: TMP_DIR),
+    before: -> () { cleanup_dir(TMP_DIR) },
+  }
+]
+
+#-----------------------------------------------------------------------------------
+
+class TestSetup
+  attr_reader :random, :num_threads, :registry
+  attr_reader :metrics, :threads # Simple arrays
+  attr_reader :data_points # Hash, indexed by Thread ID, with an array of points to observe
+  attr_reader :start_event
+
+  def initialize(store, num_threads)
+    Prometheus::Client.config.data_store = @store = store
+
+    @random = Random.new(RANDOM_SEED) # Repeatable random numbers for each test
+    @start_event = Concurrent::Event.new # Event all threads wait on to start, once set up
+    @num_threads = num_threads
+    @threads = []
+    @metrics = []
+    @data_points = {}
+    @registry = Prometheus::Client::Registry.new
+
+    setup_threads
+    setup_metrics
+    create_datapoints
+  end
+
+  def observe!
+    start_event.set # Release the threads to process their events
+    threads.each { |thr| thr.join } # Wait for all threads to finish and die
+  end
+
+  def export!(expected_output)
+    output = Prometheus::Client::Formats::Text.marshal(registry)
+
+    # Output validation doesn't work for NoopStore
+    return nil if @store.is_a?(NoopStore)
+
+    puts "\nWARNING: Empty output" if !output || output.empty?
+
+    # If this is the first store to run for this number of threads, store expected_output
+    return output if expected_output.nil?
+
+    # Otherwise, make sure this store's output was the same as the previous one.
+    # If it isn't, there's probably a bug in the store
+    return output if output == expected_output
+
+    # Outputs don't match. Report
+    expected_filename = "data_mismatch_#{ @store.class.name }_#{ num_threads }thr_expected.txt"
+    actual_filename = "data_mismatch_#{ @store.class.name }_#{ num_threads }thr_actual.txt"
+    puts "\nWARNING: Output Mismatch.\nSee #{ expected_filename }\nand #{ actual_filename }"
+
+    File.open(expected_filename, 'w') {|f| f.write(expected_output) }
+    File.open(actual_filename, 'w') {|f| f.write(output) }
+
+    return expected_output
+  end
+
+  private
+
+  def setup_threads
+    latch = Concurrent::CountDownLatch.new(num_threads)
+
+    num_threads.times do |i|
+      threads << Thread.new(i) do |thread_id|
+        latch.count_down
+        start_event.wait # Wait for the test to start
+        thread_run(thread_id) # Process this thread's events
+      end
+    end
+
+    latch.wait # Wait for all threads to have started
+  end
+
+  def setup_metrics
+    NUM_COUNTERS.times do |i|
+      labelset = generate_labelset
+      counter =  Prometheus::Client::Counter.new(
+        "counter#{ i }".to_sym,
+        docstring: "Counter #{ i }",
+        labels: labelset.keys,
+        preset_labels: labelset
+      )
+
+      metrics << counter
+    end
+
+    NUM_HISTOGRAMS.times do |i|
+      labelset = generate_labelset
+      histogram =  Prometheus::Client::Histogram.new(
+        "histogram#{ i }".to_sym,
+        docstring: "Histogram #{ i }",
+        labels: labelset.keys,
+        preset_labels: labelset
+      )
+
+      metrics << histogram
+    end
+
+    metrics.each { |metric| registry.register(metric) }
+  end
+
+  def create_datapoints
+    num_threads.times do |i|
+      data_points[i] = []
+    end
+
+    thread_id = 0
+    DATA_POINTS.times do |i|
+      thread_id = (thread_id + 1) % num_threads
+      metric = random_metric
+
+      if metric.type == :counter
+        data_points[thread_id] << [metric]
+      else
+        data_points[thread_id] << [metric, random.rand * 10]
+      end
+    end
+  end
+
+  def thread_run(thread_id)
+    thread_points = data_points[thread_id]
+    thread_points.each do |point|
+      metric = point[0]
+      if metric.type == :counter
+        metric.increment
+      else
+        metric.observe(point[1])
+      end
+    end
+  end
+
+  def generate_labelset
+    num_labels = random.rand(MAX_LABELS - MIN_LABELS + 1) + MIN_LABELS
+    (1..num_labels).map {|j| ["label#{ j }".to_sym, "foo"] }.to_h
+  end
+
+  def random_metric
+    metrics[random.rand(metrics.count)]
+  end
+end
+
+def cleanup_dir(dir)
+  Dir.glob("#{ dir }/*").each { |file| File.delete(file) }
+end
+
+#-----------------------------------------------------------------------------------
+
+# Monkey-patch the exporter to round Float numbers
+# This is necessary in order to compare outputs from different stores, and make sure
+# the user-built stores are working correctly.
+#
+# In multi-threaded scenarios, adding up a large amount of floats in different orders
+# results in small rounding errors when adding the same numbers. This is not a bug
+# in the store, or anywhere, it's the nature of Floats.
+# E.g.: 4909.026018536727
+#    vs 4909.026018536722
+#
+# In the real exporter, this is not a problem, because the exported numbers are still
+# correct, but when comparing one to the other, these tiny deltas result in false
+# alarms for *all* stores under multiple threads.
+#
+# Monkey-patching the output line to round the number allows us to compare these outputs
+# without any noticeable downside.
+module Prometheus
+  module Client
+    module Formats
+      module Text
+        def self.metric(name, labels, value)
+          format(METRIC_LINE, name, labels, value.round(6))
+        end
+      end
+    end
+  end
+end
+
+#-----------------------------------------------------------------------------------
+
+Benchmark.bm(45) do |bm|
+  THREAD_COUNTS.each do |num_threads|
+    expected_exporter_output = nil
+
+    STORES.each do |store_test|
+      # Single Threaded stores can't run in multiple threads
+      next if store_test[:max_threads] && num_threads > store_test[:max_threads]
+
+      # Cleanup before test
+      store_test[:before].call if store_test[:before]
+
+      test_setup = TestSetup.new(store_test[:store], num_threads)
+      store_name = store_test[:store].class.name.split('::').last
+      test_name ="#{ (store_test[:name] || store_name).ljust(25) } x#{ num_threads }"
+
+      bm.report("Observe #{test_name}") { test_setup.observe! }
+      bm.report("Export  #{test_name}") do
+        expected_exporter_output = test_setup.export!(expected_exporter_output)
+      end
+    end
+
+    puts "-" * 80
+  end
+end
+
+
+#--------------------------------------------------------------------------------------
+# Sample Results:
+#
+# Only counters, no labels, DirectFileStore stored in TMPFS, Ruby 2.5.1
+# ----------------------------------------------------------------
+#                                                     user     system      total        real
+# Observe NoopStore                 x1            0.390845   0.019915   0.410760 (  0.413240)
+# Export  NoopStore                 x1            0.000462   0.000029   0.000491 (  0.000489)
+# Observe SingleThreaded            x1            0.946516   0.044122   0.990638 (  0.990801)
+# Export  SingleThreaded            x1            0.000837   0.000000   0.000837 (  0.000838)
+# Observe Synchronized              x1            4.038891   0.000000   4.038891 (  4.039304)
+# Export  Synchronized              x1            0.001227   0.000000   0.001227 (  0.001229)
+# Observe DirectFileStore           x1            7.414242   1.732539   9.146781 (  9.147389)
+# Export  DirectFileStore           x1            0.009920   0.000243   0.010163 (  0.010170)
+# --------------------------------------------------------------------------------
+# Observe NoopStore                 x2            0.337919   0.000000   0.337919 (  0.337575)
+# Export  NoopStore                 x2            0.000404   0.000000   0.000404 (  0.000379)
+# Observe Synchronized              x2            4.313595   0.008714   4.322309 (  4.314901)
+# Export  Synchronized              x2            0.001649   0.000155   0.001804 (  0.001809)
+# Observe DirectFileStore           x2           22.193105  12.739370  34.932475 ( 21.503215)
+# Export  DirectFileStore           x2            0.005982   0.008480   0.014462 (  0.014471)
+#
+#
+#
+# Default benchmark (Mix of Counters and Histograms, and up to 4 labels),
+# DirectFileStore stored in TMPFS, Ruby 2.5.1
+# ------------------------------------------
+#                                                     user     system      total        real
+# Observe NoopStore                 x1            0.994314   0.027816   1.022130 (  1.025121)
+# Export  NoopStore                 x1            0.000537   0.000032   0.000569 (  0.000574)
+# Observe SingleThreaded            x1            4.439427   0.027929   4.467356 (  4.470777)
+# Export  SingleThreaded            x1            0.006244   0.000000   0.006244 (  0.006250)
+# Observe Synchronized              x1            8.292962   0.000000   8.292962 (  8.293737)
+# Export  Synchronized              x1            0.006698   0.000000   0.006698 (  0.006706)
+# Observe DirectFileStore           x1           13.448161   2.517563  15.965724 ( 15.967281)
+# Export  DirectFileStore           x1            0.020115   0.004012   0.024127 (  0.024135)
+# --------------------------------------------------------------------------------
+# Observe NoopStore                 x2            1.342963   0.020541   1.363504 (  1.354383)
+# Export  NoopStore                 x2            0.002923   0.000000   0.002923 (  0.002927)
+# Observe Synchronized              x2            8.810914   0.029352   8.840266 (  8.828600)
+# Export  Synchronized              x2            0.007535   0.000000   0.007535 (  0.007540)
+# Observe DirectFileStore           x2           41.483649  19.362639  60.846288 ( 39.026703)
+# Export  DirectFileStore           x2            0.010133   0.013159   0.023292 (  0.023302)

--- a/spec/benchmarks/labels.rb
+++ b/spec/benchmarks/labels.rb
@@ -1,0 +1,127 @@
+require 'benchmark/ips'
+require 'prometheus/client'
+require 'prometheus/client/counter'
+require 'prometheus/client/data_stores/single_threaded'
+
+# Compare the time it takes to observe metrics that have labels (disregarding the actual
+# data store)
+#
+# This benchmark compares 3 different metrics, with 0, 2 and 100 labels respectively,
+# and how using `with_values` for some, or all their label values affects performance.
+#
+# The hypothesis here is that, once labels are introduced, we're validating those labels
+# in every observation, but if those labels are "cached" using `with_labels`, we skip that
+# validation which should be *considerably* faster.
+#
+# This completely disregards the storage of this data in memory, and it's highly likely
+# that more labels will make things slower in the data store, even if the metrics themselves
+# don't add overhead. So the fact that using `with_labels` with all labels adds no overhead
+# to the metric itself doesn't mean labels have no overhead.
+#
+# To see what it looks like with the best-case scenario data store, uncomment the line
+# that sets the `data_store` to `SingleThreaded`
+#-------------------------------------------------------------------------------------
+# Store that doesn't do anything, so we can focus as much as possible on the timings of
+# the Metric itself
+class NoopStore
+  def for_metric(metric_name, metric_type:, metric_settings: {})
+    MetricStore.new
+  end
+
+  class MetricStore
+    def synchronize
+      yield
+    end
+
+    def set(labels:, val:); end
+    def increment(labels:, by: 1); end
+    def get(labels:); end
+    def all_values; end
+  end
+end
+
+Prometheus::Client.config.data_store = NoopStore.new # No data storage
+# Prometheus::Client.config.data_store = Prometheus::Client::DataStores::SingleThreaded.new # Simple data storage
+
+#-------------------------------------------------------------------------------------
+# Set up of the 3 metrics, plus their half-cached and full-cached versions
+NO_LABELS_COUNTER = Prometheus::Client::Counter.new(
+  :no_labels,
+  docstring: "Counter with no labels"
+)
+
+TWO_LABELSET = { label1: "a", label2: "b"}
+LAST_ONE_LABELSET = { label2: "b"}
+TWO_LABELS_COUNTER = Prometheus::Client::Counter.new(
+  :two_labels,
+  docstring: "Counter with 2 labels",
+  labels: [:label1, :label2]
+)
+TWO_LABELS_ONE_CACHED = TWO_LABELS_COUNTER.with_labels(label1: "a")
+TWO_LABELS_ALL_CACHED = TWO_LABELS_COUNTER.with_labels(label1: "a", label2: "b")
+
+
+HUNDRED_LABELS = (1..100).map{|i| "label#{ i }".to_sym }
+HUNDRED_LABELSET = (1..100).map{|i| ["label#{ i }".to_sym, i.to_s] }.to_h
+FIRST_FIFTY_LABELSET = (1..50).map{|i| ["label#{ i }".to_sym, i.to_s] }.to_h
+LAST_FIFTY_LABELSET = (51..100).map{|i| ["label#{ i }".to_sym, i.to_s] }.to_h
+
+HUNDRED_LABELS_COUNTER = Prometheus::Client::Counter.new(
+  :hundred_labels,
+  docstring: "Counter with 100 labels",
+  labels: HUNDRED_LABELS
+)
+HUNDRED_LABELS_HALF_CACHED = HUNDRED_LABELS_COUNTER.with_labels(FIRST_FIFTY_LABELSET)
+HUNDRED_LABELS_ALL_CACHED = HUNDRED_LABELS_COUNTER.with_labels(HUNDRED_LABELSET)
+
+#-------------------------------------------------------------------------------------
+# Actual Benchmark
+
+Benchmark.ips do |x|
+  x.config(:time => 5, :warmup => 2)
+
+  x.report("0 labels") { NO_LABELS_COUNTER.increment }
+  x.report("2 labels") { TWO_LABELS_COUNTER.increment(labels: TWO_LABELSET) }
+  x.report("100 labels") { HUNDRED_LABELS_COUNTER.increment(labels: HUNDRED_LABELSET) }
+
+  x.report("2 lab, half cached") { TWO_LABELS_ONE_CACHED.increment(labels: LAST_ONE_LABELSET) }
+  x.report("100 lab, half cached") { HUNDRED_LABELS_HALF_CACHED.increment(labels: LAST_FIFTY_LABELSET) }
+
+  x.report("2 lab, all cached") { TWO_LABELS_ALL_CACHED.increment }
+  x.report("100 lab, all cached") { HUNDRED_LABELS_ALL_CACHED.increment }
+end
+
+#-------------------------------------------------------------------------------------
+# Conclusion:
+#
+# Without a data store:
+#
+#             0 labels      3.592M (± 3.7%) i/s -     18.081M in   5.039832s
+#             2 labels    502.898k (± 3.2%) i/s -      2.536M in   5.048618s
+#           100 labels     19.467k (± 4.8%) i/s -     98.280k in   5.061444s
+#   2 lab, half cached    432.844k (± 3.0%) i/s -      2.180M in   5.041123s
+# 100 lab, half cached     20.444k (± 3.4%) i/s -    103.636k in   5.075070s
+#    2 lab, all cached      3.668M (± 3.3%) i/s -     18.338M in   5.004442s
+#  100 lab, all cached      3.711M (± 4.0%) i/s -     18.544M in   5.005362s
+#
+# As we expected, labels introduce a significant overhead, even in small numbers, but
+# if they are all pre-set, the effect is negligible.
+# Pre-setting *some* labels, however, has no performance impact. It may still be desirable
+# to avoid repetition, though.
+#
+# So, if observing measurements in a tight loop, it's highly recommended to use `with_labels`
+# and pre-set all labels.
+#
+#
+# With the simplest possible data store:
+#
+#             0 labels      1.275M (± 3.1%) i/s -      6.419M in   5.038946s
+#             2 labels    195.293k (± 4.3%) i/s -    974.600k in   5.000375s
+#           100 labels      6.410k (± 7.5%) i/s -     32.022k in   5.028417s
+#   2 lab, half cached    187.255k (± 3.5%) i/s -    948.618k in   5.072189s
+# 100 lab, half cached      6.846k (± 2.7%) i/s -     34.424k in   5.031776s
+#    2 lab, all cached    376.353k (± 3.3%) i/s -      1.890M in   5.025963s
+#  100 lab, all cached     11.669k (± 3.0%) i/s -     58.752k in   5.039468s
+#
+# As mentioned above, once we're storing the data, labels *can* have a serious impact,
+# and that impact will be highly store dependent.

--- a/spec/examples/data_store_example.rb
+++ b/spec/examples/data_store_example.rb
@@ -1,0 +1,58 @@
+# encoding: UTF-8
+
+shared_examples_for Prometheus::Client::DataStores do
+  describe "MetricStore#set and #get" do
+    it "returns the value set for each labelset" do
+      metric_store.set(labels: { foo: "bar" }, val: 5)
+      metric_store.set(labels: { foo: "baz" }, val: 2)
+      expect(metric_store.get(labels: { foo: "bar" })).to eq(5)
+      expect(metric_store.get(labels: { foo: "baz" })).to eq(2)
+      expect(metric_store.get(labels: { foo: "bat" })).to eq(0)
+    end
+  end
+
+  describe "MetricStore#increment" do
+    it "returns the value set for each labelset" do
+      metric_store.set(labels: { foo: "bar" }, val: 5)
+      metric_store.set(labels: { foo: "baz" }, val: 2)
+
+      metric_store.increment(labels: { foo: "bar" })
+      metric_store.increment(labels: { foo: "baz" }, by: 7)
+      metric_store.increment(labels: { foo: "zzz" }, by: 3)
+
+      expect(metric_store.get(labels: { foo: "bar" })).to eq(6)
+      expect(metric_store.get(labels: { foo: "baz" })).to eq(9)
+      expect(metric_store.get(labels: { foo: "zzz" })).to eq(3)
+    end
+  end
+
+  describe "MetricStore#synchronize" do
+    # I'm not sure it's possible to actually test that this synchronizes, but at least
+    # it should run the passed block
+    it "accepts a block and runs it" do
+      a = 0
+      metric_store.synchronize{ a += 1 }
+      expect(a).to eq(1)
+    end
+
+    # This is just a safety check that we're not getting "nested transaction" issues
+    it "allows modifying the store while in synchronized block" do
+      metric_store.synchronize do
+        metric_store.increment(labels: { foo: "bar" })
+        metric_store.increment(labels: { foo: "baz" })
+      end
+    end
+  end
+
+  describe "MetricStore#all_values" do
+    it "returns all specified labelsets, with their associated value" do
+      metric_store.set(labels: { foo: "bar" }, val: 5)
+      metric_store.set(labels: { foo: "baz" }, val: 2)
+
+      expect(metric_store.all_values).to eq(
+        { foo: "bar" } => 5.0,
+        { foo: "baz" } => 2.0,
+      )
+    end
+  end
+end

--- a/spec/examples/metric_example.rb
+++ b/spec/examples/metric_example.rb
@@ -14,7 +14,7 @@ shared_examples_for Prometheus::Client::Metric do
       expect do
         described_class.new(:foo,
                             docstring: 'foo docstring',
-                            base_labels: { __name__: 'reserved' })
+                            preset_labels: { __name__: 'reserved' })
       end.to raise_exception exception
     end
 
@@ -56,8 +56,12 @@ shared_examples_for Prometheus::Client::Metric do
       expect(subject.get).to be_a(type)
     end
 
-    it 'returns the current metric value for a given label set' do
-      expect(subject.get(labels: { test: 'label' })).to be_a(type)
+    context "with a subject that expects labels" do
+      subject { described_class.new(:foo, docstring: 'Labels', labels: [:test]) }
+
+      it 'returns the current metric value for a given label set' do
+        expect(subject.get(labels: { test: 'label' })).to be_a(type)
+      end
     end
   end
 end

--- a/spec/examples/metric_example.rb
+++ b/spec/examples/metric_example.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
 shared_examples_for Prometheus::Client::Metric do
-  subject { described_class.new(:foo, 'foo description') }
+  subject { described_class.new(:foo, docstring: 'foo description') }
 
   describe '.new' do
     it 'returns a new metric' do
@@ -12,19 +12,21 @@ shared_examples_for Prometheus::Client::Metric do
       exception = Prometheus::Client::LabelSetValidator::ReservedLabelError
 
       expect do
-        described_class.new(:foo, 'foo docstring', __name__: 'reserved')
+        described_class.new(:foo,
+                            docstring: 'foo docstring',
+                            base_labels: { __name__: 'reserved' })
       end.to raise_exception exception
     end
 
     it 'raises an exception if the given name is blank' do
       expect do
-        described_class.new(nil, 'foo')
+        described_class.new(nil, docstring: 'foo')
       end.to raise_exception ArgumentError
     end
 
     it 'raises an exception if docstring is missing' do
       expect do
-        described_class.new(:foo, '')
+        described_class.new(:foo, docstring: '')
       end.to raise_exception ArgumentError
     end
 
@@ -37,7 +39,7 @@ shared_examples_for Prometheus::Client::Metric do
         "abc\ndef".to_sym,
       ].each do |name|
         expect do
-          described_class.new(name, 'foo')
+          described_class.new(name, docstring: 'foo')
         end.to raise_exception(ArgumentError)
       end
     end
@@ -55,7 +57,7 @@ shared_examples_for Prometheus::Client::Metric do
     end
 
     it 'returns the current metric value for a given label set' do
-      expect(subject.get(test: 'label')).to be_a(type)
+      expect(subject.get(labels: { test: 'label' })).to be_a(type)
     end
   end
 end

--- a/spec/prometheus/client/counter_spec.rb
+++ b/spec/prometheus/client/counter_spec.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+require 'prometheus/client'
 require 'prometheus/client/counter'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Counter do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::Synchronized.new
+  end
+
   let(:expected_labels) { [] }
 
   let(:counter) do

--- a/spec/prometheus/client/counter_spec.rb
+++ b/spec/prometheus/client/counter_spec.rb
@@ -4,7 +4,9 @@ require 'prometheus/client/counter'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Counter do
-  let(:counter) { Prometheus::Client::Counter.new(:foo, 'foo description') }
+  let(:counter) do
+    Prometheus::Client::Counter.new(:foo, docstring: 'foo description')
+  end
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { Float }
@@ -20,20 +22,20 @@ describe Prometheus::Client::Counter do
     it 'increments the counter for a given label set' do
       expect do
         expect do
-          counter.increment(test: 'label')
-        end.to change { counter.get(test: 'label') }.by(1.0)
+          counter.increment(labels: { test: 'label' })
+        end.to change { counter.get(labels: { test: 'label' }) }.by(1.0)
       end.to_not change { counter.get }
     end
 
     it 'increments the counter by a given value' do
       expect do
-        counter.increment({}, 5)
+        counter.increment(by: 5)
       end.to change { counter.get }.by(5.0)
     end
 
     it 'raises an ArgumentError on negative increments' do
       expect do
-        counter.increment({}, -1)
+        counter.increment(by: -1)
       end.to raise_error ArgumentError
     end
 

--- a/spec/prometheus/client/counter_spec.rb
+++ b/spec/prometheus/client/counter_spec.rb
@@ -45,6 +45,12 @@ describe Prometheus::Client::Counter do
           end.to change { counter.get(labels: { test: 'label' }) }.by(1.0)
         end.to_not change { counter.get(labels: { test: 'other' }) }
       end
+
+      it 'can pre-set labels using `with_labels`' do
+        expect { counter.increment }
+          .to raise_error(Prometheus::Client::LabelSetValidator::InvalidLabelSetError)
+        expect { counter.with_labels(test: 'label').increment }.not_to raise_error
+      end
     end
 
     it 'increments the counter by a given value' do

--- a/spec/prometheus/client/data_stores/direct_file_store_spec.rb
+++ b/spec/prometheus/client/data_stores/direct_file_store_spec.rb
@@ -1,0 +1,169 @@
+# encoding: UTF-8
+
+require 'prometheus/client/data_stores/direct_file_store'
+require 'examples/data_store_example'
+
+describe Prometheus::Client::DataStores::DirectFileStore do
+  subject { described_class.new(dir: "/tmp/prometheus_test") }
+  let(:metric_store) { subject.for_metric(:metric_name, metric_type: :counter) }
+
+  # Reset the PStores
+  before do
+    Dir.glob('/tmp/prometheus_test/*').each { |file| File.delete(file) }
+  end
+
+  it_behaves_like Prometheus::Client::DataStores
+
+  it "only accepts valid :aggregation as Metric Settings" do
+    expect do
+      subject.for_metric(:metric_name,
+                         metric_type: :counter,
+                         metric_settings: { aggregation: Prometheus::Client::DataStores::DirectFileStore::SUM })
+    end.not_to raise_error
+
+    expect do
+      subject.for_metric(:metric_name,
+                         metric_type: :counter,
+                         metric_settings: { aggregation: :invalid })
+    end.to raise_error(Prometheus::Client::DataStores::DirectFileStore::InvalidStoreSettingsError)
+
+    expect do
+      subject.for_metric(:metric_name,
+                         metric_type: :counter,
+                         metric_settings: { some_setting: true })
+    end.to raise_error(Prometheus::Client::DataStores::DirectFileStore::InvalidStoreSettingsError)
+  end
+
+  it "raises when aggregating if we get to that that point with an invalid aggregation mode" do
+    # This is basically just for coverage of a safety clause that can never be reached
+    allow(subject).to receive(:validate_metric_settings) # turn off validation
+
+    metric = subject.for_metric(:metric_name,
+                                metric_type: :counter,
+                                metric_settings: { aggregation: :invalid })
+    metric.increment(labels: {}, by: 1)
+
+    expect do
+      metric.all_values
+    end.to raise_error(Prometheus::Client::DataStores::DirectFileStore::InvalidStoreSettingsError)
+  end
+
+  it "opens the same file twice, if it already exists" do
+    # Testing this simply for coverage
+    ms = metric_store
+    ms.increment(labels: {}, by: 1)
+
+    ms2 = subject.for_metric(:metric_name, metric_type: :counter)
+    ms2.increment(labels: {}, by: 1)
+  end
+
+
+  it "sums values from different processes" do
+    allow(Process).to receive(:pid).and_return(12345)
+    metric_store1 = subject.for_metric(:metric_name, metric_type: :counter)
+    metric_store1.set(labels: { foo: "bar" }, val: 1)
+    metric_store1.set(labels: { foo: "baz" }, val: 7)
+    metric_store1.set(labels: { foo: "yyy" }, val: 3)
+
+    allow(Process).to receive(:pid).and_return(23456)
+    metric_store2 = subject.for_metric(:metric_name, metric_type: :counter)
+    metric_store2.set(labels: { foo: "bar" }, val: 3)
+    metric_store2.set(labels: { foo: "baz" }, val: 2)
+    metric_store2.set(labels: { foo: "zzz" }, val: 1)
+
+    expect(metric_store2.all_values).to eq(
+      { foo: "bar" } => 4.0,
+      { foo: "baz" } => 9.0,
+      { foo: "yyy" } => 3.0,
+      { foo: "zzz" } => 1.0,
+    )
+
+    # Both processes should return the same value
+    expect(metric_store1.all_values).to eq(metric_store2.all_values)
+  end
+
+  context "with a metric that takes MAX instead of SUM" do
+    it "reports the maximum values from different processes" do
+      allow(Process).to receive(:pid).and_return(12345)
+      metric_store1 = subject.for_metric(
+        :metric_name,
+        metric_type: :gauge,
+        metric_settings: { aggregation: :max }
+      )
+      metric_store1.set(labels: { foo: "bar" }, val: 1)
+      metric_store1.set(labels: { foo: "baz" }, val: 7)
+      metric_store1.set(labels: { foo: "yyy" }, val: 3)
+
+      allow(Process).to receive(:pid).and_return(23456)
+      metric_store2 = subject.for_metric(
+        :metric_name,
+        metric_type: :gauge,
+        metric_settings: { aggregation: :max }
+      )
+      metric_store2.set(labels: { foo: "bar" }, val: 3)
+      metric_store2.set(labels: { foo: "baz" }, val: 2)
+      metric_store2.set(labels: { foo: "zzz" }, val: 1)
+
+      expect(metric_store1.all_values).to eq(
+        { foo: "bar" } => 3.0,
+        { foo: "baz" } => 7.0,
+        { foo: "yyy" } => 3.0,
+        { foo: "zzz" } => 1.0,
+      )
+
+      # Both processes should return the same value
+      expect(metric_store1.all_values).to eq(metric_store2.all_values)
+    end
+  end
+
+  context "with a metric that takes MIN instead of SUM" do
+    it "reports the minimum values from different processes" do
+      allow(Process).to receive(:pid).and_return(12345)
+      metric_store1 = subject.for_metric(
+        :metric_name,
+        metric_type: :gauge,
+        metric_settings: { aggregation: :min }
+      )
+      metric_store1.set(labels: { foo: "bar" }, val: 1)
+      metric_store1.set(labels: { foo: "baz" }, val: 7)
+      metric_store1.set(labels: { foo: "yyy" }, val: 3)
+
+      allow(Process).to receive(:pid).and_return(23456)
+      metric_store2 = subject.for_metric(
+        :metric_name,
+        metric_type: :gauge,
+        metric_settings: { aggregation: :min }
+      )
+      metric_store2.set(labels: { foo: "bar" }, val: 3)
+      metric_store2.set(labels: { foo: "baz" }, val: 2)
+      metric_store2.set(labels: { foo: "zzz" }, val: 1)
+
+      expect(metric_store1.all_values).to eq(
+        { foo: "bar" } => 1.0,
+        { foo: "baz" } => 2.0,
+        { foo: "yyy" } => 3.0,
+        { foo: "zzz" } => 1.0,
+      )
+
+      # Both processes should return the same value
+      expect(metric_store1.all_values).to eq(metric_store2.all_values)
+    end
+  end
+
+  it "resizes the File if metrics get too big" do
+     truncate_calls_count = 0
+     allow_any_instance_of(Prometheus::Client::DataStores::DirectFileStore::FileMappedDict).
+       to receive(:resize_file).and_wrap_original do |original_method, *args, &block|
+    
+       truncate_calls_count += 1
+       original_method.call(*args, &block)
+     end
+
+    really_long_string = "a" * 500_000
+    10.times do |i|
+      metric_store.set(labels: { foo: "#{ really_long_string }#{ i }" }, val: 1)
+    end
+
+    expect(truncate_calls_count).to be >= 3
+  end
+end

--- a/spec/prometheus/client/data_stores/single_threaded_spec.rb
+++ b/spec/prometheus/client/data_stores/single_threaded_spec.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+
+require 'prometheus/client/data_stores/single_threaded'
+require 'examples/data_store_example'
+
+describe Prometheus::Client::DataStores::SingleThreaded do
+  subject { described_class.new }
+  let(:metric_store) { subject.for_metric(:metric_name, metric_type: :counter) }
+
+  it_behaves_like Prometheus::Client::DataStores
+
+  it "does not accept Metric Settings" do
+    expect do
+      subject.for_metric(:metric_name,
+                         metric_type: :counter,
+                         metric_settings: { some_setting: true })
+    end.to raise_error(Prometheus::Client::DataStores::SingleThreaded::InvalidStoreSettingsError)
+  end
+end

--- a/spec/prometheus/client/data_stores/synchronized_spec.rb
+++ b/spec/prometheus/client/data_stores/synchronized_spec.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+
+require 'prometheus/client/data_stores/synchronized'
+require 'examples/data_store_example'
+
+describe Prometheus::Client::DataStores::Synchronized do
+  subject { described_class.new }
+  let(:metric_store) { subject.for_metric(:metric_name, metric_type: :counter) }
+
+  it_behaves_like Prometheus::Client::DataStores
+
+  it "does not accept Metric Settings" do
+    expect do
+      subject.for_metric(:metric_name,
+                         metric_type: :counter,
+                         metric_settings: { some_setting: true })
+    end.to raise_error(Prometheus::Client::DataStores::Synchronized::InvalidStoreSettingsError)
+  end
+end

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -20,27 +20,24 @@ describe Prometheus::Client::Formats::Text do
       double(
         name: :foo,
         docstring: 'foo description',
-        base_labels: { umlauts: 'Björn', utf: '佖佥' },
         type: :counter,
         values: {
-          { code: 'red' }   => 42.0,
-          { code: 'green' } => 3.14E42,
-          { code: 'blue' }  => -1.23e-45,
+          { umlauts: 'Björn', utf: '佖佥', code: 'red' }   => 42.0,
+          { umlauts: 'Björn', utf: '佖佥', code: 'green' } => 3.14E42,
+          { umlauts: 'Björn', utf: '佖佥', code: 'blue' }  => -1.23e-45,
         },
       ),
       double(
         name: :bar,
         docstring: "bar description\nwith newline",
-        base_labels: { status: 'success' },
         type: :gauge,
         values: {
-          { code: 'pink' } => 15.0,
+          { status: 'success', code: 'pink' } => 15.0,
         },
       ),
       double(
         name: :baz,
         docstring: 'baz "description" \\escaping',
-        base_labels: {},
         type: :counter,
         values: {
           { text: "with \"quotes\", \\escape \n and newline" } => 15.0,
@@ -49,16 +46,14 @@ describe Prometheus::Client::Formats::Text do
       double(
         name: :qux,
         docstring: 'qux description',
-        base_labels: { for: 'sake' },
         type: :summary,
         values: {
-          { code: '1' } => summary_value,
+          { for: 'sake', code: '1' } => summary_value,
         },
       ),
       double(
         name: :xuq,
         docstring: 'xuq description',
-        base_labels: {},
         type: :histogram,
         values: {
           { code: 'ah' } => histogram_value,

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -4,9 +4,7 @@ require 'prometheus/client/formats/text'
 
 describe Prometheus::Client::Formats::Text do
   let(:summary_value) do
-    { 0.5 => 4.2, 0.9 => 8.32, 0.99 => 15.3 }.tap do |value|
-      allow(value).to receive_messages(sum: 1243.21, total: 93)
-    end
+    Struct.new(:sum, :total).new(1243.21, 93.0)
   end
 
   let(:histogram_value) do
@@ -79,11 +77,8 @@ bar{status="success",code="pink"} 15.0
 baz{text="with \"quotes\", \\escape \n and newline"} 15.0
 # TYPE qux summary
 # HELP qux qux description
-qux{for="sake",code="1",quantile="0.5"} 4.2
-qux{for="sake",code="1",quantile="0.9"} 8.32
-qux{for="sake",code="1",quantile="0.99"} 15.3
 qux_sum{for="sake",code="1"} 1243.21
-qux_count{for="sake",code="1"} 93
+qux_count{for="sake",code="1"} 93.0
 # TYPE xuq histogram
 # HELP xuq xuq description
 xuq_bucket{code="ah",le="10"} 1.0

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -4,13 +4,11 @@ require 'prometheus/client/formats/text'
 
 describe Prometheus::Client::Formats::Text do
   let(:summary_value) do
-    Struct.new(:sum, :total).new(1243.21, 93.0)
+    { "count" => 93.0, "sum" => 1243.21 }
   end
 
   let(:histogram_value) do
-    { 10 => 1.0, 20 => 2.0, 30 => 2.0 }.tap do |value|
-      allow(value).to receive_messages(sum: 15.2, total: 2.0)
-    end
+    { 10 => 1.0, 20 => 2.0, 30 => 2.0, "+Inf" => 2.0, "sum" => 15.2 }
   end
 
   let(:registry) do

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -45,6 +45,12 @@ describe Prometheus::Client::Gauge do
           end.to change { gauge.get(labels: { test: 'value' }) }.from(0).to(42)
         end.to_not change { gauge.get(labels: { test: 'other' }) }
       end
+
+      it 'can pre-set labels using `with_labels`' do
+        expect { gauge.set(10) }
+          .to raise_error(Prometheus::Client::LabelSetValidator::InvalidLabelSetError)
+        expect { gauge.with_labels(test: 'value').set(10) }.not_to raise_error
+      end
     end
 
     context 'given an invalid value' do

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+require 'prometheus/client'
 require 'prometheus/client/gauge'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Gauge do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::Synchronized.new
+  end
+
   let(:expected_labels) { [] }
 
   let(:gauge) do
@@ -13,14 +19,14 @@ describe Prometheus::Client::Gauge do
   end
 
   it_behaves_like Prometheus::Client::Metric do
-    let(:type) { NilClass }
+    let(:type) { Float }
   end
 
   describe '#set' do
     it 'sets a metric value' do
       expect do
         gauge.set(42)
-      end.to change { gauge.get }.from(nil).to(42)
+      end.to change { gauge.get }.from(0).to(42)
     end
 
     it 'raises an InvalidLabelSetError if sending unexpected labels' do
@@ -36,7 +42,7 @@ describe Prometheus::Client::Gauge do
         expect do
           expect do
             gauge.set(42, labels: { test: 'value' })
-          end.to change { gauge.get(labels: { test: 'value' }) }.from(nil).to(42)
+          end.to change { gauge.get(labels: { test: 'value' }) }.from(0).to(42)
         end.to_not change { gauge.get(labels: { test: 'other' }) }
       end
     end

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -4,7 +4,7 @@ require 'prometheus/client/gauge'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Gauge do
-  let(:gauge) { Prometheus::Client::Gauge.new(:foo, 'foo description') }
+  let(:gauge) { Prometheus::Client::Gauge.new(:foo, docstring: 'foo description') }
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { NilClass }
@@ -13,22 +13,22 @@ describe Prometheus::Client::Gauge do
   describe '#set' do
     it 'sets a metric value' do
       expect do
-        gauge.set({}, 42)
+        gauge.set(42)
       end.to change { gauge.get }.from(nil).to(42)
     end
 
     it 'sets a metric value for a given label set' do
       expect do
         expect do
-          gauge.set({ test: 'value' }, 42)
-        end.to change { gauge.get(test: 'value') }.from(nil).to(42)
+          gauge.set(42, labels: { test: 'value' })
+        end.to change { gauge.get(labels: { test: 'value' }) }.from(nil).to(42)
       end.to_not change { gauge.get }
     end
 
     context 'given an invalid value' do
       it 'raises an ArgumentError' do
         expect do
-          gauge.set({}, nil)
+          gauge.set(nil)
         end.to raise_exception(ArgumentError)
       end
     end
@@ -36,7 +36,7 @@ describe Prometheus::Client::Gauge do
 
   describe '#increment' do
     before do
-      gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)
+      gauge.set(0, labels: RSpec.current_example.metadata[:labels] || {})
     end
 
     it 'increments the gauge' do
@@ -48,14 +48,14 @@ describe Prometheus::Client::Gauge do
     it 'increments the gauge for a given label set', labels: { test: 'one' } do
       expect do
         expect do
-          gauge.increment(test: 'one')
-        end.to change { gauge.get(test: 'one') }.by(1.0)
-      end.to_not change { gauge.get(test: 'another') }
+          gauge.increment(labels: { test: 'one' })
+        end.to change { gauge.get(labels: { test: 'one' }) }.by(1.0)
+      end.to_not change { gauge.get(labels: { test: 'another' }) }
     end
 
     it 'increments the gauge by a given value' do
       expect do
-        gauge.increment({}, 5)
+        gauge.increment(by: 5)
       end.to change { gauge.get }.by(5.0)
     end
 
@@ -76,7 +76,7 @@ describe Prometheus::Client::Gauge do
 
   describe '#decrement' do
     before do
-      gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)
+      gauge.set(0, labels: RSpec.current_example.metadata[:labels] || {})
     end
 
     it 'increments the gauge' do
@@ -88,14 +88,14 @@ describe Prometheus::Client::Gauge do
     it 'decrements the gauge for a given label set', labels: { test: 'one' } do
       expect do
         expect do
-          gauge.decrement(test: 'one')
-        end.to change { gauge.get(test: 'one') }.by(-1.0)
-      end.to_not change { gauge.get(test: 'another') }
+          gauge.decrement(labels: { test: 'one' })
+        end.to change { gauge.get(labels: { test: 'one' }) }.by(-1.0)
+      end.to_not change { gauge.get(labels: { test: 'another' }) }
     end
 
     it 'decrements the gauge by a given value' do
       expect do
-        gauge.decrement({}, 5)
+        gauge.decrement(by: 5)
       end.to change { gauge.get }.by(-5.0)
     end
 

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -5,7 +5,7 @@ require 'examples/metric_example'
 
 describe Prometheus::Client::Histogram do
   let(:histogram) do
-    described_class.new(:bar, 'bar description', {}, [2.5, 5, 10])
+    described_class.new(:bar, docstring: 'bar description', buckets: [2.5, 5, 10])
   end
 
   it_behaves_like Prometheus::Client::Metric do
@@ -15,7 +15,7 @@ describe Prometheus::Client::Histogram do
   describe '#initialization' do
     it 'raise error for unsorted buckets' do
       expect do
-        described_class.new(:bar, 'bar description', {}, [5, 2.5, 10])
+        described_class.new(:bar, docstring: 'bar description', buckets: [5, 2.5, 10])
       end.to raise_error ArgumentError
     end
   end
@@ -23,45 +23,46 @@ describe Prometheus::Client::Histogram do
   describe '#observe' do
     it 'records the given value' do
       expect do
-        histogram.observe({}, 5)
+        histogram.observe(5)
       end.to change { histogram.get }
     end
 
     it 'raise error for le labels' do
       expect do
-        histogram.observe({ le: 1 }, 5)
+        histogram.observe(5, labels: { le: 1 })
       end.to raise_error ArgumentError
     end
   end
 
   describe '#get' do
     before do
-      histogram.observe({ foo: 'bar' }, 3)
-      histogram.observe({ foo: 'bar' }, 5.2)
-      histogram.observe({ foo: 'bar' }, 13)
-      histogram.observe({ foo: 'bar' }, 4)
+      histogram.observe(3, labels: { foo: 'bar' })
+      histogram.observe(5.2, labels: { foo: 'bar' })
+      histogram.observe(13, labels: { foo: 'bar' })
+      histogram.observe(4, labels: { foo: 'bar' })
     end
 
     it 'returns a set of buckets values' do
-      expect(histogram.get(foo: 'bar')).to eql(2.5 => 0.0, 5 => 2.0, 10 => 3.0)
+      expect(histogram.get(labels: { foo: 'bar' }))
+        .to eql(2.5 => 0.0, 5 => 2.0, 10 => 3.0)
     end
 
     it 'returns a value which responds to #sum and #total' do
-      value = histogram.get(foo: 'bar')
+      value = histogram.get(labels: { foo: 'bar' })
 
       expect(value.sum).to eql(25.2)
       expect(value.total).to eql(4.0)
     end
 
     it 'uses zero as default value' do
-      expect(histogram.get({})).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
+      expect(histogram.get).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
     end
   end
 
   describe '#values' do
     it 'returns a hash of all recorded summaries' do
-      histogram.observe({ status: 'bar' }, 3)
-      histogram.observe({ status: 'foo' }, 6)
+      histogram.observe(3, labels: { status: 'bar' })
+      histogram.observe(6, labels: { status: 'foo' })
 
       expect(histogram.values).to eql(
         { status: 'bar' } => { 2.5 => 0.0, 5 => 1.0, 10 => 1.0 },

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+require 'prometheus/client'
 require 'prometheus/client/histogram'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Histogram do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::Synchronized.new
+  end
+
   let(:expected_labels) { [] }
 
   let(:histogram) do
@@ -75,18 +81,22 @@ describe Prometheus::Client::Histogram do
 
     it 'returns a set of buckets values' do
       expect(histogram.get(labels: { foo: 'bar' }))
-        .to eql(2.5 => 0.0, 5 => 2.0, 10 => 3.0)
+        .to eql(
+          2.5 => 0.0, 5 => 2.0, 10 => 3.0, "+Inf" => 4.0, "count" => 4.0, "sum" => 25.2
+        )
     end
 
-    it 'returns a value which responds to #sum and #total' do
+    it 'returns a value which includes sum and count' do
       value = histogram.get(labels: { foo: 'bar' })
 
-      expect(value.sum).to eql(25.2)
-      expect(value.total).to eql(4.0)
+      expect(value["sum"]).to eql(25.2)
+      expect(value["count"]).to eql(4.0)
     end
 
     it 'uses zero as default value' do
-      expect(histogram.get(labels: { foo: '' })).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
+      expect(histogram.get(labels: { foo: '' })).to eql(
+        2.5 => 0.0, 5 => 0.0, 10 => 0.0, "+Inf" => 0.0, "count" => 0.0, "sum" => 0.0
+      )
     end
   end
 
@@ -98,8 +108,8 @@ describe Prometheus::Client::Histogram do
       histogram.observe(6, labels: { status: 'foo' })
 
       expect(histogram.values).to eql(
-        { status: 'bar' } => { 2.5 => 0.0, 5 => 1.0, 10 => 1.0 },
-        { status: 'foo' } => { 2.5 => 0.0, 5 => 0.0, 10 => 1.0 },
+        { status: 'bar' } => { 2.5 => 0.0, 5 => 1.0, 10 => 1.0, "+Inf" => 1.0, "sum" => 3.0 },
+        { status: 'foo' } => { 2.5 => 0.0, 5 => 0.0, 10 => 1.0, "+Inf" => 1.0, "sum" => 6.0 },
       )
     end
   end

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -82,20 +82,19 @@ describe Prometheus::Client::Histogram do
     it 'returns a set of buckets values' do
       expect(histogram.get(labels: { foo: 'bar' }))
         .to eql(
-          "2.5" => 0.0, "5" => 2.0, "10" => 3.0, "+Inf" => 4.0, "count" => 4.0, "sum" => 25.2
+          "2.5" => 0.0, "5" => 2.0, "10" => 3.0, "+Inf" => 4.0, "sum" => 25.2
         )
     end
 
-    it 'returns a value which includes sum and count' do
+    it 'returns a value which includes sum' do
       value = histogram.get(labels: { foo: 'bar' })
 
       expect(value["sum"]).to eql(25.2)
-      expect(value["count"]).to eql(4.0)
     end
 
     it 'uses zero as default value' do
       expect(histogram.get(labels: { foo: '' })).to eql(
-        "2.5" => 0.0, "5" => 0.0, "10" => 0.0, "+Inf" => 0.0, "count" => 0.0, "sum" => 0.0
+        "2.5" => 0.0, "5" => 0.0, "10" => 0.0, "+Inf" => 0.0, "sum" => 0.0
       )
     end
   end

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -82,7 +82,7 @@ describe Prometheus::Client::Histogram do
     it 'returns a set of buckets values' do
       expect(histogram.get(labels: { foo: 'bar' }))
         .to eql(
-          2.5 => 0.0, 5 => 2.0, 10 => 3.0, "+Inf" => 4.0, "count" => 4.0, "sum" => 25.2
+          "2.5" => 0.0, "5" => 2.0, "10" => 3.0, "+Inf" => 4.0, "count" => 4.0, "sum" => 25.2
         )
     end
 
@@ -95,7 +95,7 @@ describe Prometheus::Client::Histogram do
 
     it 'uses zero as default value' do
       expect(histogram.get(labels: { foo: '' })).to eql(
-        2.5 => 0.0, 5 => 0.0, 10 => 0.0, "+Inf" => 0.0, "count" => 0.0, "sum" => 0.0
+        "2.5" => 0.0, "5" => 0.0, "10" => 0.0, "+Inf" => 0.0, "count" => 0.0, "sum" => 0.0
       )
     end
   end
@@ -108,8 +108,8 @@ describe Prometheus::Client::Histogram do
       histogram.observe(6, labels: { status: 'foo' })
 
       expect(histogram.values).to eql(
-        { status: 'bar' } => { 2.5 => 0.0, 5 => 1.0, 10 => 1.0, "+Inf" => 1.0, "sum" => 3.0 },
-        { status: 'foo' } => { 2.5 => 0.0, 5 => 0.0, 10 => 1.0, "+Inf" => 1.0, "sum" => 6.0 },
+        { status: 'bar' } => { "2.5" => 0.0, "5" => 1.0, "10" => 1.0, "+Inf" => 1.0, "sum" => 3.0 },
+        { status: 'foo' } => { "2.5" => 0.0, "5" => 0.0, "10" => 1.0, "+Inf" => 1.0, "sum" => 6.0 },
       )
     end
   end

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -66,6 +66,12 @@ describe Prometheus::Client::Histogram do
           end.to change { histogram.get(labels: { test: 'value' }) }
         end.to_not change { histogram.get(labels: { test: 'other' }) }
       end
+
+      it 'can pre-set labels using `with_labels`' do
+        expect { histogram.observe(2) }
+          .to raise_error(Prometheus::Client::LabelSetValidator::InvalidLabelSetError)
+        expect { histogram.with_labels(test: 'value').observe(2) }.not_to raise_error
+      end
     end
   end
 

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -4,8 +4,13 @@ require 'prometheus/client/histogram'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Histogram do
+  let(:expected_labels) { [] }
+
   let(:histogram) do
-    described_class.new(:bar, docstring: 'bar description', buckets: [2.5, 5, 10])
+    described_class.new(:bar,
+                        docstring: 'bar description',
+                        labels: expected_labels,
+                        buckets: [2.5, 5, 10])
   end
 
   it_behaves_like Prometheus::Client::Metric do
@@ -17,6 +22,12 @@ describe Prometheus::Client::Histogram do
       expect do
         described_class.new(:bar, docstring: 'bar description', buckets: [5, 2.5, 10])
       end.to raise_error ArgumentError
+    end
+
+    it 'raise error for `le` label' do
+      expect do
+        described_class.new(:bar, docstring: 'bar description', labels: [:le])
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
     end
   end
 
@@ -30,11 +41,31 @@ describe Prometheus::Client::Histogram do
     it 'raise error for le labels' do
       expect do
         histogram.observe(5, labels: { le: 1 })
-      end.to raise_error ArgumentError
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+    end
+
+    it 'raises an InvalidLabelSetError if sending unexpected labels' do
+      expect do
+        histogram.observe(5, labels: { foo: 'bar' })
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
+    end
+
+    context "with a an expected label set" do
+      let(:expected_labels) { [:test] }
+
+      it 'observes a value for a given label set' do
+        expect do
+          expect do
+            histogram.observe(5, labels: { test: 'value' })
+          end.to change { histogram.get(labels: { test: 'value' }) }
+        end.to_not change { histogram.get(labels: { test: 'other' }) }
+      end
     end
   end
 
   describe '#get' do
+    let(:expected_labels) { [:foo] }
+
     before do
       histogram.observe(3, labels: { foo: 'bar' })
       histogram.observe(5.2, labels: { foo: 'bar' })
@@ -55,11 +86,13 @@ describe Prometheus::Client::Histogram do
     end
 
     it 'uses zero as default value' do
-      expect(histogram.get).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
+      expect(histogram.get(labels: { foo: '' })).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
     end
   end
 
   describe '#values' do
+    let(:expected_labels) { [:status] }
+
     it 'returns a hash of all recorded summaries' do
       histogram.observe(3, labels: { status: 'bar' })
       histogram.observe(6, labels: { status: 'foo' })

--- a/spec/prometheus/client/label_set_validator_spec.rb
+++ b/spec/prometheus/client/label_set_validator_spec.rb
@@ -13,67 +13,67 @@ describe Prometheus::Client::LabelSetValidator do
     end
   end
 
-  describe '#valid?' do
+  describe '#validate_symbols!' do
     it 'returns true for a valid label check' do
-      expect(validator.valid?(version: 'alpha')).to eql(true)
+      expect(validator.validate_symbols!(version: 'alpha')).to eql(true)
     end
 
     it 'raises Invaliddescribed_classError if a label set is not a hash' do
       expect do
-        validator.valid?('invalid')
+        validator.validate_symbols!('invalid')
       end.to raise_exception invalid
     end
 
     it 'raises InvalidLabelError if a label key is not a symbol' do
       expect do
-        validator.valid?('key' => 'value')
+        validator.validate_symbols!('key' => 'value')
       end.to raise_exception(described_class::InvalidLabelError)
     end
 
     it 'raises InvalidLabelError if a label key starts with __' do
       expect do
-        validator.valid?(__reserved__: 'key')
+        validator.validate_symbols!(__reserved__: 'key')
       end.to raise_exception(described_class::ReservedLabelError)
     end
 
     it 'raises ReservedLabelError if a label key is reserved' do
       [:job, :instance].each do |label|
         expect do
-          validator.valid?(label => 'value')
+          validator.validate_symbols!(label => 'value')
         end.to raise_exception(described_class::ReservedLabelError)
       end
     end
   end
 
-  describe '#validate' do
+  describe '#validate_labelset!' do
     let(:expected_labels) { [:method, :code] }
 
     it 'returns a given valid label set' do
       hash = { method: 'get', code: '200' }
 
-      expect(validator.validate(hash)).to eql(hash)
+      expect(validator.validate_labelset!(hash)).to eql(hash)
     end
 
-    it 'raises an exception if a given label set is not `valid?`' do
+    it 'raises an exception if a given label set is not `validate_symbols!`' do
       input = 'broken'
-      expect(validator).to receive(:valid?).with(input).and_raise(invalid)
+      expect(validator).to receive(:validate_symbols!).with(input).and_raise(invalid)
 
-      expect { validator.validate(input) }.to raise_exception(invalid)
+      expect { validator.validate_labelset!(input) }.to raise_exception(invalid)
     end
 
     it 'raises an exception if there are unexpected labels' do
       expect do
-        validator.validate(method: 'get', code: '200', exception: 'NoMethodError')
+        validator.validate_labelset!(method: 'get', code: '200', exception: 'NoMethodError')
       end.to raise_exception(invalid, /keys given: \[:code, :exception, :method\] vs. keys expected: \[:code, :method\]/)
     end
 
     it 'raises an exception if there are missing labels' do
       expect do
-        validator.validate(method: 'get')
+        validator.validate_labelset!(method: 'get')
       end.to raise_exception(invalid, /keys given: \[:method\] vs. keys expected: \[:code, :method\]/)
 
       expect do
-        validator.validate(code: '200')
+        validator.validate_labelset!(code: '200')
       end.to raise_exception(invalid, /keys given: \[:code\] vs. keys expected: \[:code, :method\]/)
     end
   end

--- a/spec/prometheus/client/registry_spec.rb
+++ b/spec/prometheus/client/registry_spec.rb
@@ -68,7 +68,7 @@ describe Prometheus::Client::Registry do
 
   describe '#counter' do
     it 'registers a new counter metric container and returns the counter' do
-      metric = registry.counter(:test, 'test docstring')
+      metric = registry.counter(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Counter)
     end
@@ -76,7 +76,7 @@ describe Prometheus::Client::Registry do
 
   describe '#gauge' do
     it 'registers a new gauge metric container and returns the gauge' do
-      metric = registry.gauge(:test, 'test docstring')
+      metric = registry.gauge(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Gauge)
     end
@@ -84,7 +84,7 @@ describe Prometheus::Client::Registry do
 
   describe '#summary' do
     it 'registers a new summary metric container and returns the summary' do
-      metric = registry.summary(:test, 'test docstring')
+      metric = registry.summary(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Summary)
     end
@@ -92,7 +92,7 @@ describe Prometheus::Client::Registry do
 
   describe '#histogram' do
     it 'registers a new histogram metric container and returns the histogram' do
-      metric = registry.histogram(:test, 'test docstring')
+      metric = registry.histogram(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Histogram)
     end

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -4,13 +4,24 @@ require 'prometheus/client/summary'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Summary do
+  let(:expected_labels) { [] }
+
   let(:summary) do
     Prometheus::Client::Summary.new(:bar,
-                                    docstring: 'bar description')
+                                    docstring: 'bar description',
+                                    labels: expected_labels)
   end
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { Hash }
+  end
+
+  describe '#initialization' do
+    it 'raise error for `quantile` label' do
+      expect do
+        described_class.new(:bar, docstring: 'bar description', labels: [:quantile])
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+    end
   end
 
   describe '#observe' do
@@ -19,9 +30,34 @@ describe Prometheus::Client::Summary do
         summary.observe(5)
       end.to change { summary.get }
     end
+    it 'raise error for quantile labels' do
+      expect do
+        summary.observe(5, labels: { quantile: 1 })
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+    end
+
+    it 'raises an InvalidLabelSetError if sending unexpected labels' do
+      expect do
+        summary.observe(5, labels: { foo: 'bar' })
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
+    end
+
+    context "with a an expected label set" do
+      let(:expected_labels) { [:test] }
+
+      it 'observes a value for a given label set' do
+        expect do
+          expect do
+            summary.observe(5, labels: { test: 'value' })
+          end.to change { summary.get(labels: { test: 'value' }) }
+        end.to_not change { summary.get(labels: { test: 'other' }) }
+      end
+    end
   end
 
   describe '#get' do
+    let(:expected_labels) { [:foo] }
+
     before do
       summary.observe(3, labels: { foo: 'bar' })
       summary.observe(5.2, labels: { foo: 'bar' })
@@ -47,6 +83,8 @@ describe Prometheus::Client::Summary do
   end
 
   describe '#values' do
+    let(:expected_labels) { [:status] }
+
     it 'returns a hash of all recorded summaries' do
       summary.observe(3, labels: { status: 'bar' })
       summary.observe(5, labels: { status: 'foo' })

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -4,7 +4,10 @@ require 'prometheus/client/summary'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Summary do
-  let(:summary) { Prometheus::Client::Summary.new(:bar, 'bar description') }
+  let(:summary) do
+    Prometheus::Client::Summary.new(:bar,
+                                    docstring: 'bar description')
+  end
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { Hash }
@@ -13,39 +16,40 @@ describe Prometheus::Client::Summary do
   describe '#observe' do
     it 'records the given value' do
       expect do
-        summary.observe({}, 5)
+        summary.observe(5)
       end.to change { summary.get }
     end
   end
 
   describe '#get' do
     before do
-      summary.observe({ foo: 'bar' }, 3)
-      summary.observe({ foo: 'bar' }, 5.2)
-      summary.observe({ foo: 'bar' }, 13)
-      summary.observe({ foo: 'bar' }, 4)
+      summary.observe(3, labels: { foo: 'bar' })
+      summary.observe(5.2, labels: { foo: 'bar' })
+      summary.observe(13, labels: { foo: 'bar' })
+      summary.observe(4, labels: { foo: 'bar' })
     end
 
     it 'returns a set of quantile values' do
-      expect(summary.get(foo: 'bar')).to eql(0.5 => 4, 0.9 => 5.2, 0.99 => 5.2)
+      expect(summary.get(labels: { foo: 'bar' }))
+        .to eql(0.5 => 4, 0.9 => 5.2, 0.99 => 5.2)
     end
 
     it 'returns a value which responds to #sum and #total' do
-      value = summary.get(foo: 'bar')
+      value = summary.get(labels: { foo: 'bar' })
 
       expect(value.sum).to eql(25.2)
       expect(value.total).to eql(4)
     end
 
     it 'uses nil as default value' do
-      expect(summary.get({})).to eql(0.5 => nil, 0.9 => nil, 0.99 => nil)
+      expect(summary.get).to eql(0.5 => nil, 0.9 => nil, 0.99 => nil)
     end
   end
 
   describe '#values' do
     it 'returns a hash of all recorded summaries' do
-      summary.observe({ status: 'bar' }, 3)
-      summary.observe({ status: 'foo' }, 5)
+      summary.observe(3, labels: { status: 'bar' })
+      summary.observe(5, labels: { status: 'foo' })
 
       expect(summary.values).to eql(
         { status: 'bar' } => { 0.5 => 3, 0.9 => 3, 0.99 => 3 },

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -61,6 +61,12 @@ describe Prometheus::Client::Summary do
           end.to change { summary.get(labels: { test: 'value' })["count"] }
         end.to_not change { summary.get(labels: { test: 'other' })["count"] }
       end
+
+      it 'can pre-set labels using `with_labels`' do
+        expect { summary.observe(2) }
+          .to raise_error(Prometheus::Client::LabelSetValidator::InvalidLabelSetError)
+        expect { summary.with_labels(test: 'value').observe(2) }.not_to raise_error
+      end
     end
   end
 

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -104,6 +104,8 @@ describe Prometheus::Middleware::Collector do
         original_app,
         registry: registry,
         counter_label_builder: lambda do |env, code|
+          next { code: nil, method: nil } if env.empty?
+
           {
             code:   code,
             method: env['REQUEST_METHOD'].downcase,

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -50,7 +50,7 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo' }
-    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.25 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include("0.1" => 0, "0.25" => 1)
   end
 
   it 'normalizes paths containing numeric IDs by default' do
@@ -64,7 +64,7 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:id/bars' }
-    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.5 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include("0.1" => 0, "0.5" => 1)
   end
 
   it 'normalizes paths containing UUIDs by default' do
@@ -78,7 +78,7 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:uuid/bars' }
-    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.5 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include("0.1" => 0, "0.5" => 1)
   end
 
   context 'when the app raises an exception' do

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -41,11 +41,11 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_requests_total
     labels = { method: 'get', path: '/foo', code: '200' }
-    expect(registry.get(metric).get(labels)).to eql(1.0)
+    expect(registry.get(metric).get(labels: labels)).to eql(1.0)
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo' }
-    expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.25 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.25 => 1)
   end
 
   it 'normalizes paths containing numeric IDs by default' do
@@ -55,11 +55,11 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_requests_total
     labels = { method: 'get', path: '/foo/:id/bars', code: '200' }
-    expect(registry.get(metric).get(labels)).to eql(1.0)
+    expect(registry.get(metric).get(labels: labels)).to eql(1.0)
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:id/bars' }
-    expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.5 => 1)
   end
 
   it 'normalizes paths containing UUIDs by default' do
@@ -69,11 +69,11 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_requests_total
     labels = { method: 'get', path: '/foo/:uuid/bars', code: '200' }
-    expect(registry.get(metric).get(labels)).to eql(1.0)
+    expect(registry.get(metric).get(labels: labels)).to eql(1.0)
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:uuid/bars' }
-    expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.5 => 1)
   end
 
   context 'when the app raises an exception' do
@@ -94,7 +94,7 @@ describe Prometheus::Middleware::Collector do
 
       metric = :http_server_exceptions_total
       labels = { exception: 'NoMethodError' }
-      expect(registry.get(metric).get(labels)).to eql(1.0)
+      expect(registry.get(metric).get(labels: labels)).to eql(1.0)
     end
   end
 
@@ -117,7 +117,7 @@ describe Prometheus::Middleware::Collector do
 
       metric = :http_server_requests_total
       labels = { method: 'get', code: '200' }
-      expect(registry.get(metric).get(labels)).to eql(1.0)
+      expect(registry.get(metric).get(labels: labels)).to eql(1.0)
     end
   end
 

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -6,6 +6,11 @@ require 'prometheus/middleware/collector'
 describe Prometheus::Middleware::Collector do
   include Rack::Test::Methods
 
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::Synchronized.new
+  end
+
   let(:registry) do
     Prometheus::Client::Registry.new
   end

--- a/spec/prometheus/middleware/exporter_spec.rb
+++ b/spec/prometheus/middleware/exporter_spec.rb
@@ -29,7 +29,7 @@ describe Prometheus::Middleware::Exporter do
 
     shared_examples 'ok' do |headers, fmt|
       it "responds with 200 OK and Content-Type #{fmt::CONTENT_TYPE}" do
-        registry.counter(:foo, 'foo counter').increment({}, 9)
+        registry.counter(:foo, docstring: 'foo counter').increment(by: 9)
 
         get '/metrics', nil, headers
 


### PR DESCRIPTION
This PR attempts to address the first set of changes required for the objectives outlined in [Issue 94](https://github.com/prometheus/client_ruby/issues/94)

This is an excerpt from that issue, please check [the full text](https://github.com/prometheus/client_ruby/issues/94) for more context:

As it currently stands, the Prometheus Ruby Client has a few issues that make it hard to adopt in mainstream Ruby projects, particularly in Web applications:
1. [Pre-fork servers can't report metrics](https://github.com/prometheus/client_ruby/issues/9), because each process has their own set of data, and what gets reported to Prometheus depends on which process responds to the scrape request.
2. The current Client, being one of the first clients created, doesn't follow several of the [Best Practices and Guidelines](https://prometheus.io/docs/instrumenting/writing_clientlibs/). 

### Objectives
- Follow [client conventions and best practices](https://prometheus.io/docs/instrumenting/writing_clientlibs/)
- Add the notion of Pluggable backends. Client should be configurable with different backends: thread-safe (default), thread-unsafe (lock-free for performance on single-threaded cases), multiprocess, etc.
  - Consumers should be able to build and plug their own backends based on their use cases.

------------------

Points this PR tackles:

- A few refactorings / improvements here and there
- Add keyword arguments to methods, to be more idiomatic within modern Ruby standards
- Create the concept of Data Stores, separate from the Metrics the user declares, to have a clear interface that allows us to swap different implementations.
- Introduce 3 data stores, tailored to 3 specific scenarios: Single Threaded, Multi-threaded, and Multi-Process applications.

------------

This PR will be very hard to read if you're looking at all the changes at once. We recommend reading it commit-by-commit, since each one is an incremental step towards the final state, and they have very extensive explanations on the why and how of each step.

I'm sorry about that, it was the only practical way of making this large refactoring. I would've liked for it to be many small, individual PRs, but most of these changes depended on the previous ones.

------------

Short explanation on our rationale for the built-in Multi-Process Data Store being based on Files:
- We experimented with multiple different possible data stores, and we focused strongly on benchmarking them to see which would ones present acceptable performance.
- Since there seems to be a community direction towards using MMaps, we put a good bit of effort on having an `MmapStore`
- We took @juliusv 's efforts in this repo, in the `multiprocess` branch, as a starting point, and adapted it to the Data Stores interface we're presenting here, which was quite easy. They play along well together.
- We then worked on fixing a few stability bugs, and on a few performance improvements with it, and we were quite happy with the results.
- HOWEVER, there is one stability issue we haven't yet been fully able to solve. Under some conditions, this store crashes. We can't reproduce this in our dev machines, but Travis actually crashes frequently.
- We also experimenting taking that exact same approach, but removing the mmap. Basically, it uses files, but indexing them in the same way @juliusv is indexing the mmap, reading and writing the binary-packed Floats directly into their offsets in those files, which is a great idea. This approach is *surprisingly* fast (mostly because of FS caching, we're not really touching the disk for the most part). So, for the time being, we're proposing the `DirectFileStore`, as the official way of working with pre-fork servers.
- Some performance numbers. These is the time to increment a counters, without labels, on a single thread:
  - SingleThreadedStore (basically, simplest store possible, just a hash): 1μs
  - SynchronizedStore (a hash with a mutex around): 4μs
  - MMapStore: 6μs
  - DirectFileStore: 9μs

- So, MMaps are 30% faster, and we consider that enough improvement to continue trying to get that to work, but at 9μs per observation, the DirectFileStore is extremely stable and reliable, and it's pretty fast. 
- Our rationale is that it's better to release this as is, knowing full well that is safe, and that it solves the pre-fork problem for the vast majority of users, rather than rely on a less stable approach, for a performance improvement that'll be important for some users, but not for the majority.

That said, we are preparing a separate repo (https://github.com/gocardless/prometheus-client-ruby-data-stores-experiments) where we're going to dump the rest of the stores we created, more benchmarks, and extensive documentation on all the exploration we did. We think this will be a great starting point for anyone making their ow stores, and we encourage the community to try and help us finalize the MmapStore (or make their own, if they have a better approach), but we don't think all of that belongs in this repo, it'd add a lot of clutter and confusion for consumers of the gem.