### PR TITLE
Fix pushgateway paths.

### DIFF
--- a/lib/prometheus/client/push.rb
+++ b/lib/prometheus/client/push.rb
@@ -14,8 +14,8 @@ module Prometheus
     # Pushgateway.
     class Push
       DEFAULT_GATEWAY = 'http://localhost:9091'.freeze
-      PATH            = '/metrics/jobs/%s'.freeze
-      INSTANCE_PATH   = '/metrics/jobs/%s/instances/%s'.freeze
+      PATH            = '/metrics/job/%s'.freeze
+      INSTANCE_PATH   = '/metrics/job/%s/instances/%s'.freeze
       SUPPORTED_SCHEMES = %w(http https).freeze
 
       attr_reader :job, :instance, :gateway, :path

--- a/spec/prometheus/client/push_spec.rb
+++ b/spec/prometheus/client/push_spec.rb
@@ -61,19 +61,19 @@ describe Prometheus::Client::Push do
     it 'uses the default metrics path if no instance value given' do
       push = Prometheus::Client::Push.new('test-job')
 
-      expect(push.path).to eql('/metrics/jobs/test-job')
+      expect(push.path).to eql('/metrics/job/test-job')
     end
 
     it 'uses the full metrics path if an instance value is given' do
       push = Prometheus::Client::Push.new('bar-job', 'foo')
 
-      expect(push.path).to eql('/metrics/jobs/bar-job/instances/foo')
+      expect(push.path).to eql('/metrics/job/bar-job/instances/foo')
     end
 
     it 'escapes non-URL characters' do
       push = Prometheus::Client::Push.new('bar job', 'foo <my instance>')
 
-      expected = '/metrics/jobs/bar%20job/instances/foo%20%3Cmy%20instance%3E'
+      expected = '/metrics/job/bar%20job/instances/foo%20%3Cmy%20instance%3E'
       expect(push.path).to eql(expected)
     end
   end
@@ -81,7 +81,7 @@ describe Prometheus::Client::Push do
   describe '#request' do
     let(:content_type) { Prometheus::Client::Formats::Text::CONTENT_TYPE }
     let(:data) { Prometheus::Client::Formats::Text.marshal(registry) }
-    let(:uri) { URI.parse("#{gateway}/metrics/jobs/test-job") }
+    let(:uri) { URI.parse("#{gateway}/metrics/job/test-job") }
 
     it 'sends marshalled registry to the specified gateway' do
       request = double(:request)


### PR DESCRIPTION
Hi @grobie, please review this fix, cause currently `ruby_client` is broken.

Since pushgateway released v0.7.0 deprecated `/metrics/jobs/` interface
was removed and only singularized `/metrics/job/` support now.

See [pushgateway release notes](https://github.com/prometheus/pushgateway/releases/tag/v0.7.0) and PR that [removes deprecated API](https://github.com/prometheus/pushgateway/pull/227) 