### PR TITLE
Correct HTTP Push end point

### DIFF
--- a/lib/prometheus/client/push.rb
+++ b/lib/prometheus/client/push.rb
@@ -14,8 +14,8 @@ module Prometheus
     # Pushgateway.
     class Push
       DEFAULT_GATEWAY = 'http://localhost:9091'.freeze
-      PATH            = '/metrics/jobs/%s'.freeze
-      INSTANCE_PATH   = '/metrics/jobs/%s/instances/%s'.freeze
+      PATH            = '/metrics/job/%s'.freeze
+      INSTANCE_PATH   = '/metrics/job/%s/instances/%s'.freeze
       SUPPORTED_SCHEMES = %w(http https).freeze
 
       attr_reader :job, :instance, :gateway, :path

--- a/spec/prometheus/client/push_spec.rb
+++ b/spec/prometheus/client/push_spec.rb
@@ -61,19 +61,19 @@ describe Prometheus::Client::Push do
     it 'uses the default metrics path if no instance value given' do
       push = Prometheus::Client::Push.new('test-job')
 
-      expect(push.path).to eql('/metrics/jobs/test-job')
+      expect(push.path).to eql('/metrics/job/test-job')
     end
 
     it 'uses the full metrics path if an instance value is given' do
       push = Prometheus::Client::Push.new('bar-job', 'foo')
 
-      expect(push.path).to eql('/metrics/jobs/bar-job/instances/foo')
+      expect(push.path).to eql('/metrics/job/bar-job/instances/foo')
     end
 
     it 'escapes non-URL characters' do
       push = Prometheus::Client::Push.new('bar job', 'foo <my instance>')
 
-      expected = '/metrics/jobs/bar%20job/instances/foo%20%3Cmy%20instance%3E'
+      expected = '/metrics/job/bar%20job/instances/foo%20%3Cmy%20instance%3E'
       expect(push.path).to eql(expected)
     end
   end
@@ -81,7 +81,7 @@ describe Prometheus::Client::Push do
   describe '#request' do
     let(:content_type) { Prometheus::Client::Formats::Text::CONTENT_TYPE }
     let(:data) { Prometheus::Client::Formats::Text.marshal(registry) }
-    let(:uri) { URI.parse("#{gateway}/metrics/jobs/test-job") }
+    let(:uri) { URI.parse("#{gateway}/metrics/job/test-job") }
 
     it 'sends marshalled registry to the specified gateway' do
       request = double(:request)


### PR DESCRIPTION
As of [0.7.0](https://github.com/prometheus/pushgateway/blob/d5a56ba224c85c1c027fb069a0f421ef150a9f00/CHANGELOG.md#070--2018-12-07) the HTTP push endpoint has been changed from /jobs/ ->  /job/. 

This pull request attempt to correct that.
