### PR TITLE
Remove support for flexible labels in collector middleware

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -32,8 +32,6 @@ module Prometheus
         @app = app
         @registry = options[:registry] || Client.registry
         @metrics_prefix = options[:metrics_prefix] || 'http_server'
-        @counter_lb = options[:counter_label_builder] || COUNTER_LB
-        @duration_lb = options[:duration_label_builder] || DURATION_LB
 
         init_request_metrics
         init_exception_metrics
@@ -45,29 +43,10 @@ module Prometheus
 
       protected
 
-      aggregation = lambda do |str|
+      AGGREGATION = lambda do |str|
         str
           .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
           .gsub(%r{/\d+(/|$)}, '/:id\\1')
-      end
-
-      COUNTER_LB = proc do |env, code|
-        next { code: nil, method: nil, path: nil } if env.empty?
-
-        {
-          code:   code,
-          method: env['REQUEST_METHOD'].downcase,
-          path:   aggregation.call(env['PATH_INFO']),
-        }
-      end
-
-      DURATION_LB = proc do |env, _|
-        next { method: nil, path: nil } if env.empty?
-
-        {
-          method: env['REQUEST_METHOD'].downcase,
-          path:   aggregation.call(env['PATH_INFO']),
-        }
       end
 
       def init_request_metrics
@@ -75,12 +54,12 @@ module Prometheus
           :"#{@metrics_prefix}_requests_total",
           docstring:
             'The total number of HTTP requests handled by the Rack application.',
-          labels: @counter_lb.call({}, "").keys
+          labels: %i[code method path]
         )
         @durations = @registry.histogram(
           :"#{@metrics_prefix}_request_duration_seconds",
           docstring: 'The HTTP response duration of the Rack application.',
-          labels: @duration_lb.call({}, "").keys
+          labels: %i[method path]
         )
       end
 
@@ -103,8 +82,19 @@ module Prometheus
       end
 
       def record(env, code, duration)
-        @requests.increment(labels: @counter_lb.call(env, code))
-        @durations.observe(duration, labels: @duration_lb.call(env, code))
+        counter_labels = {
+          code:   code,
+          method: env['REQUEST_METHOD'].downcase,
+          path:   AGGREGATION.call(env['PATH_INFO']),
+        }
+
+        duration_labels = {
+          method: env['REQUEST_METHOD'].downcase,
+          path:   AGGREGATION.call(env['PATH_INFO']),
+        }
+
+        @requests.increment(labels: counter_labels)
+        @durations.observe(duration, labels: duration_labels)
       rescue
         # TODO: log unexpected exception during request recording
         nil

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -43,12 +43,6 @@ module Prometheus
 
       protected
 
-      AGGREGATION = lambda do |str|
-        str
-          .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
-          .gsub(%r{/\d+(/|$)}, '/:id\\1')
-      end
-
       def init_request_metrics
         @requests = @registry.counter(
           :"#{@metrics_prefix}_requests_total",
@@ -85,12 +79,12 @@ module Prometheus
         counter_labels = {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
-          path:   AGGREGATION.call(env['PATH_INFO']),
+          path:   strip_ids_from_path(env['PATH_INFO']),
         }
 
         duration_labels = {
           method: env['REQUEST_METHOD'].downcase,
-          path:   AGGREGATION.call(env['PATH_INFO']),
+          path:   strip_ids_from_path(env['PATH_INFO']),
         }
 
         @requests.increment(labels: counter_labels)
@@ -98,6 +92,12 @@ module Prometheus
       rescue
         # TODO: log unexpected exception during request recording
         nil
+      end
+
+      def strip_ids_from_path(path)
+        path
+          .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
+          .gsub(%r{/\d+(/|$)}, '/:id\\1')
       end
     end
   end

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -103,31 +103,6 @@ describe Prometheus::Middleware::Collector do
     end
   end
 
-  context 'when using a custom counter label builder' do
-    let(:app) do
-      described_class.new(
-        original_app,
-        registry: registry,
-        counter_label_builder: lambda do |env, code|
-          next { code: nil, method: nil } if env.empty?
-
-          {
-            code:   code,
-            method: env['REQUEST_METHOD'].downcase,
-          }
-        end,
-      )
-    end
-
-    it 'allows labels configuration' do
-      get '/foo/bar'
-
-      metric = :http_server_requests_total
-      labels = { method: 'get', code: '200' }
-      expect(registry.get(metric).get(labels: labels)).to eql(1.0)
-    end
-  end
-
   context 'when provided a custom metrics_prefix' do
     let!(:app) do
       described_class.new(

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -23,6 +23,8 @@ describe Prometheus::Middleware::Collector do
     described_class.new(original_app, registry: registry)
   end
 
+  let(:dummy_error) { RuntimeError.new("Dummy error from tests") }
+
   it 'returns the app response' do
     get '/foo'
 
@@ -32,7 +34,7 @@ describe Prometheus::Middleware::Collector do
 
   it 'handles errors in the registry gracefully' do
     counter = registry.get(:http_server_requests_total)
-    expect(counter).to receive(:increment).and_raise(NoMethodError)
+    expect(counter).to receive(:increment).and_raise(dummy_error)
 
     get '/foo'
 
@@ -84,7 +86,7 @@ describe Prometheus::Middleware::Collector do
   context 'when the app raises an exception' do
     let(:original_app) do
       lambda do |env|
-        raise NoMethodError if env['PATH_INFO'] == '/broken'
+        raise dummy_error if env['PATH_INFO'] == '/broken'
 
         [200, { 'Content-Type' => 'text/html' }, ['OK']]
       end
@@ -95,10 +97,10 @@ describe Prometheus::Middleware::Collector do
     end
 
     it 'traces exceptions' do
-      expect { get '/broken' }.to raise_error NoMethodError
+      expect { get '/broken' }.to raise_error RuntimeError
 
       metric = :http_server_exceptions_total
-      labels = { exception: 'NoMethodError' }
+      labels = { exception: 'RuntimeError' }
       expect(registry.get(metric).get(labels: labels)).to eql(1.0)
     end
   end


### PR DESCRIPTION
We decided in #111 that the current interface for this is confusing to
the point where it's more trouble than it's worth.

The alternatives we came up with result in the middleware doing almost
nothing and delegating to user-provided lambdas.

Since we're pre-1.0, we're removing this in the belief that if it turns
out to be a widely-requested feature, we can come up with something
better. Leaving this implementation in would commit us to an interface
we don't like.

Fixes #111