### PR TITLE
Bump version to 0.10.0-alpha.1

### DIFF
--- a/lib/prometheus/client/version.rb
+++ b/lib/prometheus/client/version.rb
@@ -2,6 +2,6 @@
 
 module Prometheus
   module Client
-    VERSION = '0.9.0'
+    VERSION = '0.10.0-alpha.1'
   end
 end


### PR DESCRIPTION
This prepares us to cut our first alpha release with multi-process
support, as requested in #95.

Fixes #95. Will cut the new release tomorrow.