### PR TITLE
Export per-pid values from gauges by default

### DIFF
--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -28,6 +28,7 @@ module Prometheus
         class InvalidStoreSettingsError < StandardError; end
         AGGREGATION_MODES = [MAX = :max, MIN = :min, SUM = :sum, ALL = :all]
         DEFAULT_METRIC_SETTINGS = { aggregation: SUM }
+        DEFAULT_GAUGE_SETTINGS = { aggregation: ALL }
 
         def initialize(dir:)
           @store_settings = { dir: dir }
@@ -35,7 +36,12 @@ module Prometheus
         end
 
         def for_metric(metric_name, metric_type:, metric_settings: {})
-          settings = DEFAULT_METRIC_SETTINGS.merge(metric_settings)
+          default_settings = DEFAULT_METRIC_SETTINGS
+          if metric_type == :gauge
+            default_settings = DEFAULT_GAUGE_SETTINGS
+          end
+
+          settings = default_settings.merge(metric_settings)
           validate_metric_settings(settings)
 
           MetricStore.new(metric_name: metric_name,


### PR DESCRIPTION
This changes `DirectFileStore` to use the `:all` aggregation mode for gauges by default.

I'm considering adding a config option to the store to allow the default to be overridden, for use in cases where people want to provide their own label that distinguishes between processes but changes less often than process IDs do.

I'll try to add a commit early next week for that.

Fixes #107