### PR TITLE
Remove `concurrent-ruby` dependency

### DIFF
--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -1,4 +1,3 @@
-require 'concurrent'
 require 'fileutils'
 require "cgi"
 
@@ -72,7 +71,7 @@ module Prometheus
             @store_settings = store_settings
             @values_aggregation_mode = metric_settings[:aggregation]
 
-            @rwlock = Concurrent::ReentrantReadWriteLock.new
+            @lock = Monitor.new
           end
 
           # Synchronize is used to do a multi-process Mutex, when incrementing multiple
@@ -142,7 +141,7 @@ module Prometheus
           private
 
           def in_process_sync
-            @rwlock.with_write_lock { yield }
+            @lock.synchronize { yield }
           end
 
           def store_key(labels)

--- a/lib/prometheus/client/data_stores/single_threaded.rb
+++ b/lib/prometheus/client/data_stores/single_threaded.rb
@@ -1,5 +1,3 @@
-require 'concurrent'
-
 module Prometheus
   module Client
     module DataStores

--- a/lib/prometheus/client/data_stores/synchronized.rb
+++ b/lib/prometheus/client/data_stores/synchronized.rb
@@ -1,5 +1,3 @@
-require 'concurrent'
-
 module Prometheus
   module Client
     module DataStores
@@ -27,11 +25,11 @@ module Prometheus
         class MetricStore
           def initialize
             @internal_store = Hash.new { |hash, key| hash[key] = 0.0 }
-            @rwlock = Concurrent::ReentrantReadWriteLock.new
+            @lock = Monitor.new
           end
 
           def synchronize
-            @rwlock.with_write_lock { yield }
+            @lock.synchronize { yield }
           end
 
           def set(labels:, val:)

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
 
-  s.add_dependency 'concurrent-ruby'
-
   s.add_development_dependency 'benchmark-ips'
+  s.add_development_dependency 'concurrent-ruby'
 end

--- a/spec/benchmarks/data_stores.rb
+++ b/spec/benchmarks/data_stores.rb
@@ -1,4 +1,5 @@
 require 'benchmark'
+require 'concurrent'
 require 'prometheus/client'
 require 'prometheus/client/counter'
 require 'prometheus/client/histogram'


### PR DESCRIPTION
We added this dependency to be able to use `ReadWriteLock`, which is
a reentract lock. We did not need the Read/Write locking distinction,
and at the time, we didn't know that `Monitor` was reentrant, so this
seemed to be the best solution.

Knowing that `Monitor` is reentrant, we can get rid of the dependency,
and simply use `Monitor` instead.

Note that we keep `concurrent-ruby` as a *dev* dependency, because the
performance benchmarks use other primitives provided by it to synvhronize
their threads, but it's not needed for specs to pass, or for production use.

As an added bonus, this appears to be measurably faster on multiple thread scenarios.
I only ran a quick benchmark on my laptop, so this is to be taken with a grain of salt,
but at least it doesn't seem to be worse.