### PR TITLE
Avoid revalidating labelset keys on each metric observation

### DIFF
--- a/lib/prometheus/client/label_set_validator.rb
+++ b/lib/prometheus/client/label_set_validator.rb
@@ -36,15 +36,20 @@ module Prometheus
       def validate_labelset!(labelset)
         return labelset if @validated.key?(labelset.hash)
 
-        validate_symbols!(labelset)
-
-        unless keys_match?(labelset)
-          raise InvalidLabelSetError, "labels must have the same signature " \
-                                      "(keys given: #{labelset.keys.sort} vs." \
-                                      " keys expected: #{expected_labels}"
+        begin
+          if keys_match?(labelset)
+            @validated[labelset.hash] = true
+            return labelset
+          end
+        rescue ArgumentError
+          # If labelset contains keys that are a mixture of strings and symbols, this will
+          # raise when trying to sort them, but the error should be the same:
+          # InvalidLabelSetError
         end
 
-        @validated[labelset.hash] = labelset
+        raise InvalidLabelSetError, "labels must have the same signature " \
+                                    "(keys given: #{labelset.keys} vs." \
+                                    " keys expected: #{expected_labels}"
       end
 
       private

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -47,7 +47,7 @@ describe Prometheus::Client::Histogram do
     it 'raise error for le labels' do
       expect do
         histogram.observe(5, labels: { le: 1 })
-      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
     end
 
     it 'raises an InvalidLabelSetError if sending unexpected labels' do

--- a/spec/prometheus/client/label_set_validator_spec.rb
+++ b/spec/prometheus/client/label_set_validator_spec.rb
@@ -54,17 +54,16 @@ describe Prometheus::Client::LabelSetValidator do
       expect(validator.validate_labelset!(hash)).to eql(hash)
     end
 
-    it 'raises an exception if a given label set is not `validate_symbols!`' do
-      input = 'broken'
-      expect(validator).to receive(:validate_symbols!).with(input).and_raise(invalid)
-
-      expect { validator.validate_labelset!(input) }.to raise_exception(invalid)
+    it 'returns an exception if there are malformed labels' do
+      expect do
+        validator.validate_labelset!('method' => 'get', :code => '200')
+      end.to raise_exception(invalid, /keys given: \["method", :code\] vs. keys expected: \[:code, :method\]/)
     end
 
     it 'raises an exception if there are unexpected labels' do
       expect do
         validator.validate_labelset!(method: 'get', code: '200', exception: 'NoMethodError')
-      end.to raise_exception(invalid, /keys given: \[:code, :exception, :method\] vs. keys expected: \[:code, :method\]/)
+      end.to raise_exception(invalid, /keys given: \[:method, :code, :exception\] vs. keys expected: \[:code, :method\]/)
     end
 
     it 'raises an exception if there are missing labels' do

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -42,7 +42,7 @@ describe Prometheus::Client::Summary do
     it 'raise error for quantile labels' do
       expect do
         summary.observe(5, labels: { quantile: 1 })
-      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
     end
 
     it 'raises an InvalidLabelSetError if sending unexpected labels' do


### PR DESCRIPTION
When declaring a metric, we declare what label keys will be used for it.
At that point, we validate that those are all valid keys (symbols,
match a given regex, etc).

Then, on each observation of the metric, we validate that the keys passed
in for the labels match the ones we were originally expecting, to make
sure all of those labels were set, but no others.

We were also, at that point, validating that the keys passed in are valid.
This validation is pretty slow, and it's redundant, since keys that aren't
valid won't match the expected ones anyway, so we can just compare just
that those match. This has quite a pronounced effect on performance.