### PR TITLE
Stop caching validated Labelsets, and improve Validation performance

### DIFF
--- a/lib/prometheus/client/label_set_validator.rb
+++ b/lib/prometheus/client/label_set_validator.rb
@@ -18,7 +18,6 @@ module Prometheus
       def initialize(expected_labels:, reserved_labels: [])
         @expected_labels = expected_labels.sort
         @reserved_labels = BASE_RESERVED_LABELS + reserved_labels
-        @validated = {}
       end
 
       def validate_symbols!(labels)
@@ -34,8 +33,6 @@ module Prometheus
       end
 
       def validate_labelset!(labelset)
-        return labelset if @validated.key?(labelset.hash)
-
         validate_symbols!(labelset)
 
         unless keys_match?(labelset)
@@ -44,7 +41,7 @@ module Prometheus
                                       " keys expected: #{expected_labels}"
         end
 
-        @validated[labelset.hash] = labelset
+        labelset
       end
 
       private

--- a/lib/prometheus/client/label_set_validator.rb
+++ b/lib/prometheus/client/label_set_validator.rb
@@ -33,15 +33,17 @@ module Prometheus
       end
 
       def validate_labelset!(labelset)
-        validate_symbols!(labelset)
-
-        unless keys_match?(labelset)
-          raise InvalidLabelSetError, "labels must have the same signature " \
-                                      "(keys given: #{labelset.keys.sort} vs." \
-                                      " keys expected: #{expected_labels}"
+        begin
+          return labelset if keys_match?(labelset)
+        rescue ArgumentError
+          # If labelset contains keys that are a mixture of strings and symbols, this will
+          # raise when trying to sort them, but the error should be the same:
+          # InvalidLabelSetError
         end
 
-        labelset
+        raise InvalidLabelSetError, "labels must have the same signature " \
+                                    "(keys given: #{labelset.keys} vs." \
+                                    " keys expected: #{expected_labels}"
       end
 
       private

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -47,7 +47,7 @@ describe Prometheus::Client::Histogram do
     it 'raise error for le labels' do
       expect do
         histogram.observe(5, labels: { le: 1 })
-      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
     end
 
     it 'raises an InvalidLabelSetError if sending unexpected labels' do

--- a/spec/prometheus/client/label_set_validator_spec.rb
+++ b/spec/prometheus/client/label_set_validator_spec.rb
@@ -54,17 +54,17 @@ describe Prometheus::Client::LabelSetValidator do
       expect(validator.validate_labelset!(hash)).to eql(hash)
     end
 
-    it 'raises an exception if a given label set is not `validate_symbols!`' do
-      input = 'broken'
-      expect(validator).to receive(:validate_symbols!).with(input).and_raise(invalid)
+    it 'returns an exception if there are malformed labels' do
+      expect do
+        validator.validate_labelset!('method' => 'get', :code => '200')
+      end.to raise_exception(invalid, /keys given: \["method", :code\] vs. keys expected: \[:code, :method\]/)
 
-      expect { validator.validate_labelset!(input) }.to raise_exception(invalid)
     end
 
     it 'raises an exception if there are unexpected labels' do
       expect do
         validator.validate_labelset!(method: 'get', code: '200', exception: 'NoMethodError')
-      end.to raise_exception(invalid, /keys given: \[:code, :exception, :method\] vs. keys expected: \[:code, :method\]/)
+      end.to raise_exception(invalid, /keys given: \[:method, :code, :exception\] vs. keys expected: \[:code, :method\]/)
     end
 
     it 'raises an exception if there are missing labels' do

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -42,7 +42,7 @@ describe Prometheus::Client::Summary do
     it 'raise error for quantile labels' do
       expect do
         summary.observe(5, labels: { quantile: 1 })
-      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
     end
 
     it 'raises an InvalidLabelSetError if sending unexpected labels' do


### PR DESCRIPTION
This PR fixes the race condition reported in PR #70 
Fixing that alone, by removing the cache, makes the validation quite a bit slower. However, these 2 changes together make it *much* faster, and both of these changes together have a much bigger performance effect than each in isolation, so i'm bundling them up:

---------------------------------------------
## Remove Labelset Validator Cache

Currently, when we validate a labelset on increment, we cache that we've seen this particular labelset, so we can avoid revalidating it next time we see it.

This is currently not thread-safe, since we're not synchronizing access to the hash we use for that cache. This is only a problem in non-MRI, but we are supporting those.

Removing this cache has a slight performance hit for metrics with labels, but removing the cache, in conjunction with the next commit in this PR, makes the code *way* faster than the current version, while simplifying the code, so we're opting for that.

The other alternative would have been to add a Mutex around that Hash. However, that makes it slower than the original, even if we do the change from the next commit, so we're going for the simpler, much faster, much more obvious path of not caching this validation.

This is probably also going to have a positive effect on memory usage.

---------------------------------------------
## Avoid revalidating labelset keys on each metric observation

When declaring a metric, we declare what label keys will be used for it.
At that point, we validate that those are all valid keys (symbols, match a given regex, etc).

Then, on each observation of the metric, we validate that the keys passed in for the labels match the ones we were originally expecting, to make sure all of those labels were set, but no others.

We were also, at that point, validating that the keys passed in are valid. 
This validation is pretty slow, and it's redundant, since keys that aren't valid won't match the expected ones anyway, so we can just compare just that those match. This has quite a pronounced effect on performance.

---------------------------------------------
 
## Performance effects

This is the `labels` benchmark, which measures against a `NoopStore`, to isolate the effects of just the main code of Metric / LabelSetValidator.
The main number is how many increments we can do per second, for a counter with 0, 2 and 100 labels, with none / some / all of them cached using `with_labels`.

**Current `master`**:
```
            0 labels      3.712M (± 1.8%) i/s -     18.726M in   5.046030s
            2 labels    645.876k (± 4.0%) i/s -      3.251M in   5.043007s
          100 labels     18.990k (± 3.9%) i/s -     95.676k in   5.046566s
  2 lab, half cached    668.194k (± 3.3%) i/s -      3.361M in   5.036575s
100 lab, half cached     20.290k (± 2.3%) i/s -    101.796k in   5.020072s
   2 lab, all cached      3.731M (± 2.0%) i/s -     18.831M in   5.049451s
 100 lab, all cached      3.747M (± 3.4%) i/s -     18.718M in   5.003039s
```


**This branch**:
```
            0 labels      3.732M (± 1.9%) i/s -     18.662M in   5.003057s
            2 labels      1.008M (± 2.4%) i/s -      5.039M in   5.000649s
          100 labels     31.093k (± 2.2%) i/s -    156.208k in   5.026452s
  2 lab, half cached      1.017M (± 2.3%) i/s -      5.097M in   5.013142s
100 lab, half cached     32.958k (± 2.6%) i/s -    167.076k in   5.072940s
   2 lab, all cached      3.788M (± 1.5%) i/s -     18.959M in   5.006396s
 100 lab, all cached      3.772M (± 1.9%) i/s -     18.873M in   5.005481s
```

As can be seen here, metrics with no labels or with all labels cached see no difference. However, the more common case of metrics with a few labels, uncached, sees a 50% increase in how many we can process.


-------------------------------

For comparison, this is what other changes look like
 
**Adding a mutex**:

```
            0 labels      3.622M (± 1.9%) i/s -     18.190M in   5.024468s
            2 labels    570.705k (± 1.4%) i/s -      2.874M in   5.036093s
          100 labels     19.407k (± 1.9%) i/s -     97.818k in   5.042204s
  2 lab, half cached    582.539k (± 1.1%) i/s -      2.955M in   5.073354s
100 lab, half cached     20.126k (± 2.0%) i/s -    102.204k in   5.080349s
   2 lab, all cached      3.592M (± 2.0%) i/s -     17.982M in   5.008715s
 100 lab, all cached      3.605M (± 1.4%) i/s -     18.093M in   5.020548s
```

This is predictably a bit slower than `master`


**Just not revalidating**:
```
            0 labels      3.793M (± 1.1%) i/s -     19.072M in   5.028679s
            2 labels    661.024k (± 0.9%) i/s -      3.347M in   5.064195s
          100 labels     19.345k (± 2.3%) i/s -     96.951k in   5.014353s
  2 lab, half cached    674.488k (± 1.0%) i/s -      3.425M in   5.077931s
100 lab, half cached     20.112k (± 2.4%) i/s -    101.694k in   5.059376s
   2 lab, all cached      3.702M (± 1.8%) i/s -     18.602M in   5.026144s
 100 lab, all cached      3.779M (± 1.5%) i/s -     19.016M in   5.033429s
```

This has a tiny improvement against master, since the cache prevents most of the symbol revalidation in the first place. Presumably adding a mutex around the cache here would make this slightly worse again.

**Just removing the cache**:
```
            0 labels      3.676M (± 1.4%) i/s -     18.536M in   5.043540s
            2 labels    459.403k (± 2.3%) i/s -      2.302M in   5.014364s
          100 labels     13.545k (± 1.8%) i/s -     68.640k in   5.069306s
  2 lab, half cached    459.812k (± 2.4%) i/s -      2.320M in   5.048642s
100 lab, half cached     13.894k (± 1.4%) i/s -     70.686k in   5.088610s
   2 lab, all cached      3.732M (± 1.8%) i/s -     18.695M in   5.011275s
 100 lab, all cached      3.748M (± 1.5%) i/s -     18.774M in   5.009985s
```

This is considerably slower than `master`, since we're revalidating all the things all the time. However, this combined with not revalidating symbols gives the massive speed boost seen above.