### PR TITLE
 Convert label values to strings in base Metric class

### DIFF
--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -27,7 +27,7 @@ module Prometheus
 
         @name = name
         @docstring = docstring
-        @preset_labels = preset_labels
+        @preset_labels = stringify_values(preset_labels)
 
         @store = Prometheus::Client.config.data_store.for_metric(
           name,
@@ -85,7 +85,12 @@ module Prometheus
       def label_set_for(labels)
         # We've already validated, and there's nothing to merge. Save some cycles
         return preset_labels if @all_labels_preset && labels.empty?
+        labels = stringify_values(labels)
         @validator.validate_labelset!(preset_labels.merge(labels))
+      end
+
+      def stringify_values(labels)
+        labels.map { |k,v| [k, v.to_s] }.to_h
       end
     end
   end

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -90,7 +90,10 @@ module Prometheus
       end
 
       def stringify_values(labels)
-        labels.map { |k,v| [k, v.to_s] }.to_h
+        stringified = {}
+        labels.each { |k,v| stringified[k] = v.to_s }
+
+        stringified
       end
     end
   end

--- a/spec/examples/metric_example.rb
+++ b/spec/examples/metric_example.rb
@@ -1,5 +1,31 @@
 # encoding: UTF-8
 
+# TODO: Convert these tests to use a fake metric class rather than shared examples
+#
+# Right now, we're using shared examples that we include in every metric type's tests
+# to validate the behaviour of the base metric class.
+#
+# This makes it difficult to test certain behaviour, as the interfaces of those metric
+# types differ and these tests can end up needing to know about them.
+#
+# You can see that in the tests for #get, which depend on `type` which isn't defined in
+# this file. The test files that include these shared examples have to do so with a block
+# that provides the `type` variable.
+#
+# This cropped up in a much worse way when trying to test the code that makes sure label
+# values are all strings. Writing a test here that gets included in all the real metric
+# implementations is near impossible. You need your test to call a different method to
+# alter a metric value (e.g. `set`, `increment` or `observe` depending on the metric type)
+# which means having each concrete metric type's tests passing us a lambda that we can
+# call agnostically of the metric type.
+#
+# The resultant code is confusing to follow, so we opted to duplicate those tests in each
+# metric type's test file.
+#
+# Changing this file to implement a fake metric class (e.g. `FakeTestCounter`) would let
+# us easily test the functionality of the base `Prometheus::Client::Metric` without
+# getting caught up in the specifics of the real metric types.
+
 shared_examples_for Prometheus::Client::Metric do
   subject { described_class.new(:foo, docstring: 'foo description') }
 

--- a/spec/prometheus/client/counter_spec.rb
+++ b/spec/prometheus/client/counter_spec.rb
@@ -78,5 +78,28 @@ describe Prometheus::Client::Counter do
         end.each(&:join)
       end.to change { counter.get }.by(100.0)
     end
+
+    context "with non-string label values" do
+      subject { described_class.new(:foo, docstring: 'Labels', labels: [:foo]) }
+
+      it "converts labels to strings for consistent storage" do
+        subject.increment(labels: { foo: :label })
+        expect(subject.get(labels: { foo: 'label' })).to eq(1.0)
+      end
+
+      context "and some labels preset" do
+        subject do
+          described_class.new(:foo,
+                              docstring: 'Labels',
+                              labels: [:foo, :bar],
+                              preset_labels: { foo: :label })
+        end
+
+        it "converts labels to strings for consistent storage" do
+          subject.increment(labels: { bar: :label })
+          expect(subject.get(labels: { foo: 'label', bar: 'label' })).to eq(1.0)
+        end
+      end
+    end
   end
 end

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -110,6 +110,29 @@ describe Prometheus::Client::Gauge do
         end.each(&:join)
       end.to change { gauge.get }.by(100.0)
     end
+
+    context "with non-string label values" do
+      subject { described_class.new(:foo, docstring: 'Labels', labels: [:foo]) }
+
+      it "converts labels to strings for consistent storage" do
+        subject.increment(labels: { foo: :label })
+        expect(subject.get(labels: { foo: 'label' })).to eq(1.0)
+      end
+
+      context "and some labels preset" do
+        subject do
+          described_class.new(:foo,
+                              docstring: 'Labels',
+                              labels: [:foo, :bar],
+                              preset_labels: { foo: :label })
+        end
+
+        it "converts labels to strings for consistent storage" do
+          subject.increment(labels: { bar: :label })
+          expect(subject.get(labels: { foo: 'label', bar: 'label' })).to eq(1.0)
+        end
+      end
+    end
   end
 
   describe '#decrement' do

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -73,6 +73,35 @@ describe Prometheus::Client::Histogram do
         expect { histogram.with_labels(test: 'value').observe(2) }.not_to raise_error
       end
     end
+
+    context "with non-string label values" do
+      let(:histogram) do
+        described_class.new(:foo,
+                            docstring: 'foo description',
+                            labels: [:foo],
+                            buckets: [2.5, 5, 10])
+      end
+
+      it "converts labels to strings for consistent storage" do
+        histogram.observe(5, labels: { foo: :label })
+        expect(histogram.get(labels: { foo: 'label' })["10"]).to eq(1.0)
+      end
+
+      context "and some labels preset" do
+        let(:histogram) do
+          described_class.new(:foo,
+                              docstring: 'foo description',
+                              labels: [:foo, :bar],
+                              preset_labels: { foo: :label },
+                              buckets: [2.5, 5, 10])
+        end
+
+        it "converts labels to strings for consistent storage" do
+          histogram.observe(5, labels: { bar: :label })
+          expect(histogram.get(labels: { foo: 'label', bar: 'label' })["10"]).to eq(1.0)
+        end
+      end
+    end
   end
 
   describe '#get' do

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -68,6 +68,33 @@ describe Prometheus::Client::Summary do
         expect { summary.with_labels(test: 'value').observe(2) }.not_to raise_error
       end
     end
+
+    context "with non-string label values" do
+      let(:summary) do
+        described_class.new(:foo,
+                            docstring: 'foo description',
+                            labels: [:foo])
+      end
+
+      it "converts labels to strings for consistent storage" do
+        summary.observe(5, labels: { foo: :label })
+        expect(summary.get(labels: { foo: 'label' })["count"]).to eq(1.0)
+      end
+
+      context "and some labels preset" do
+        let(:summary) do
+          described_class.new(:foo,
+                              docstring: 'foo description',
+                              labels: [:foo, :bar],
+                              preset_labels: { foo: :label })
+        end
+
+        it "converts labels to strings for consistent storage" do
+          summary.observe(5, labels: { bar: :label })
+          expect(summary.get(labels: { foo: 'label', bar: 'label' })["count"]).to eq(1.0)
+        end
+      end
+    end
   end
 
   describe '#get' do


### PR DESCRIPTION
Currently, you get an inconsistent experience when using different store
implementations (e.g. `SingleThreaded` vs `DirectFileStore`).

Because `DirectFileStore` has to write your metrics into a file, it
has to convert label values into strings. That means that when you
access them they're strings. Other stores don't do this, so you can
access them as symbols if you provided them as symbols.

To give users a consistent experience when swapping between stores, this
commit changes the Metric base class to convert the label values to
strings before they get anywhere near the underlying store.

current master:
```
            0 labels      3.732M (± 1.9%) i/s -     18.662M in   5.003057s
            2 labels      1.008M (± 2.4%) i/s -      5.039M in   5.000649s
          100 labels     31.093k (± 2.2%) i/s -    156.208k in   5.026452s
  2 lab, half cached      1.017M (± 2.3%) i/s -      5.097M in   5.013142s
100 lab, half cached     32.958k (± 2.6%) i/s -    167.076k in   5.072940s
   2 lab, all cached      3.788M (± 1.5%) i/s -     18.959M in   5.006396s
 100 lab, all cached      3.772M (± 1.9%) i/s -     18.873M in   5.005481s
```

this branch:
```
            0 labels      3.689M (± 1.3%) i/s -     18.450M in   5.002189s
            2 labels    713.961k (± 2.7%) i/s -      3.596M in   5.039963s
          100 labels     21.414k (± 1.9%) i/s -    107.378k in   5.016144s
  2 lab, half cached    791.084k (± 2.3%) i/s -      3.968M in   5.017964s
100 lab, half cached     26.202k (± 3.2%) i/s -    132.243k in   5.052325s
   2 lab, all cached      3.724M (± 1.9%) i/s -     18.718M in   5.028441s
 100 lab, all cached      3.712M (± 1.1%) i/s -     18.723M in   5.043903s
```

master before today's performance improvements:
```
            0 labels      3.712M (± 1.8%) i/s -     18.726M in   5.046030s
            2 labels    645.876k (± 4.0%) i/s -      3.251M in   5.043007s
          100 labels     18.990k (± 3.9%) i/s -     95.676k in   5.046566s
  2 lab, half cached    668.194k (± 3.3%) i/s -      3.361M in   5.036575s
100 lab, half cached     20.290k (± 2.3%) i/s -    101.796k in   5.020072s
   2 lab, all cached      3.731M (± 2.0%) i/s -     18.831M in   5.049451s
 100 lab, all cached      3.747M (± 3.4%) i/s -     18.718M in   5.003039s
```

Fixes #115