### PR TITLE
Test that stores return floats and fix DirectFileStore to do so

### DIFF
--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -133,7 +133,8 @@ module Prometheus
             end
 
             # Aggregate all the different values for each label_set
-            stores_data.each_with_object({}) do |(label_set, values), acc|
+            aggregate_hash = Hash.new { |hash, key| hash[key] = 0.0 }
+            stores_data.each_with_object(aggregate_hash) do |(label_set, values), acc|
               acc[label_set] = aggregate_values(values)
             end
           end

--- a/spec/examples/data_store_example.rb
+++ b/spec/examples/data_store_example.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+# NOTE: Do not change instances of `eql` to `eq` in this file.
+#
+# The interface of a store is a labelset (hash of hashes) to a double. It's important
+# that we check the values are doubles rather than integers. `==`, which is what `eq`
+# calls allows conversion between floats and integers (i.e. `5 == 5.0`). `eql` enforces
+# that the two numbers are of the same type.
 shared_examples_for Prometheus::Client::DataStores do
   describe "MetricStore#set and #get" do
     it "returns the value set for each labelset" do
-      expect(metric_store.get(labels: { foo: "bar" })).to eq(0.0)
+      expect(metric_store.get(labels: { foo: "bar" })).to eql(0.0)
     end
   end
 
@@ -11,9 +17,9 @@ shared_examples_for Prometheus::Client::DataStores do
     it "returns the value set for each labelset" do
       metric_store.set(labels: { foo: "bar" }, val: 5)
       metric_store.set(labels: { foo: "baz" }, val: 2)
-      expect(metric_store.get(labels: { foo: "bar" })).to eq(5)
-      expect(metric_store.get(labels: { foo: "baz" })).to eq(2)
-      expect(metric_store.get(labels: { foo: "bat" })).to eq(0)
+      expect(metric_store.get(labels: { foo: "bar" })).to eql(5.0)
+      expect(metric_store.get(labels: { foo: "baz" })).to eql(2.0)
+      expect(metric_store.get(labels: { foo: "bat" })).to eql(0.0)
     end
   end
 
@@ -26,9 +32,9 @@ shared_examples_for Prometheus::Client::DataStores do
       metric_store.increment(labels: { foo: "baz" }, by: 7)
       metric_store.increment(labels: { foo: "zzz" }, by: 3)
 
-      expect(metric_store.get(labels: { foo: "bar" })).to eq(6)
-      expect(metric_store.get(labels: { foo: "baz" })).to eq(9)
-      expect(metric_store.get(labels: { foo: "zzz" })).to eq(3)
+      expect(metric_store.get(labels: { foo: "bar" })).to eql(6.0)
+      expect(metric_store.get(labels: { foo: "baz" })).to eql(9.0)
+      expect(metric_store.get(labels: { foo: "zzz" })).to eql(3.0)
     end
   end
 
@@ -55,7 +61,7 @@ shared_examples_for Prometheus::Client::DataStores do
       metric_store.set(labels: { foo: "bar" }, val: 5)
       metric_store.set(labels: { foo: "baz" }, val: 2)
 
-      expect(metric_store.all_values).to eq(
+      expect(metric_store.all_values).to eql(
         { foo: "bar" } => 5.0,
         { foo: "baz" } => 2.0,
       )
@@ -63,7 +69,7 @@ shared_examples_for Prometheus::Client::DataStores do
 
     context "for a combination of labels that hasn't had a value set" do
       it "returns 0.0" do
-        expect(metric_store.all_values[{ foo: "bar" }]).to eq(0.0)
+        expect(metric_store.all_values[{ foo: "bar" }]).to eql(0.0)
       end
     end
   end

--- a/spec/examples/data_store_example.rb
+++ b/spec/examples/data_store_example.rb
@@ -3,6 +3,12 @@
 shared_examples_for Prometheus::Client::DataStores do
   describe "MetricStore#set and #get" do
     it "returns the value set for each labelset" do
+      expect(metric_store.get(labels: { foo: "bar" })).to eq(0.0)
+    end
+  end
+
+  describe "MetricStore#set and #get" do
+    it "returns the value set for each labelset" do
       metric_store.set(labels: { foo: "bar" }, val: 5)
       metric_store.set(labels: { foo: "baz" }, val: 2)
       expect(metric_store.get(labels: { foo: "bar" })).to eq(5)
@@ -53,6 +59,12 @@ shared_examples_for Prometheus::Client::DataStores do
         { foo: "bar" } => 5.0,
         { foo: "baz" } => 2.0,
       )
+    end
+
+    context "for a combination of labels that hasn't had a value set" do
+      it "returns 0.0" do
+        expect(metric_store.all_values[{ foo: "bar" }]).to eq(0.0)
+      end
     end
   end
 end


### PR DESCRIPTION
Up to now, we've had some subtle behavioural differences between stores;
one of which was that stores weren't consistent about what they returned
for label sets that hadn't been initialised.

This commit adds some shared examples that enforce consistent behaviour
between the stores and fixes DirectFileStore to follow that behaviour.