### PR TITLE
Reopen files in DirectFileStore when the process has forked

### DIFF
--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -154,7 +154,12 @@ module Prometheus
           end
 
           def internal_store
-            @internal_store ||= FileMappedDict.new(filemap_filename)
+            if @store_opened_by_pid != process_id
+              @store_opened_by_pid = process_id
+              @internal_store = FileMappedDict.new(filemap_filename)
+            else
+              @internal_store
+            end
           end
 
           # Filename for this metric's PStore (one per process)


### PR DESCRIPTION
Currently, if you fork after altering a metric value when using
DirectFileStore, the child process will have a handle to the original
process's metric store.

This commit detects checks for that condition on any instrumentation
event and opens a new metric file for the new PID.

Fixes #119