### PR TITLE
Fixing the Registry threading/design issues 

### DIFF
--- a/lib/prometheus/client.rb
+++ b/lib/prometheus/client.rb
@@ -8,7 +8,7 @@ module Prometheus
   module Client
     # Returns a default registry object
     def self.registry
-      @registry ||= Registry.new
+      Registry.instance
     end
 
     def self.config

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require 'thread'
+require 'prometheus/client'
 require 'prometheus/client/label_set_validator'
 
 module Prometheus

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -5,12 +5,15 @@ require 'prometheus/client/summary'
 require 'prometheus/client/gauge'
 require 'prometheus/client/histogram'
 require 'concurrent'
+require 'singleton'
 
 module Prometheus
   module Client
     # Registry
     class Registry
       class AlreadyRegisteredError < StandardError; end
+
+      include Singleton
 
       def initialize
         @metrics = {}

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -44,22 +44,27 @@ module Prometheus
       protected
 
       def init_request_metrics
-        @requests = @registry.counter(
-          :"#{@metrics_prefix}_requests_total",
+        counter_name    = "#{@metrics_prefix}_requests_total"
+        histogram_name  = "#{@metrics_prefix}_request_duration_seconds"
+
+        @requests = @registry.get(counter_name) || @registry.counter(
+          counter_name.to_sym,
           docstring:
             'The total number of HTTP requests handled by the Rack application.',
           labels: %i[code method path]
         )
-        @durations = @registry.histogram(
-          :"#{@metrics_prefix}_request_duration_seconds",
+        @durations = @registry.get(histogram_name) || @registry.histogram(
+          histogram_name.to_sym,
           docstring: 'The HTTP response duration of the Rack application.',
           labels: %i[method path]
         )
       end
 
       def init_exception_metrics
-        @exceptions = @registry.counter(
-          :"#{@metrics_prefix}_exceptions_total",
+        exception_counter_name = "#{@metrics_prefix}_exceptions_total"
+
+        @exceptions = @registry.get(exception_counter_name) || @registry.counter(
+          exception_counter_name.to_sym,
           docstring: 'The total number of exceptions raised by the Rack application.',
           labels: [:exception]
         )

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -10,7 +10,7 @@ describe Prometheus::Client::Formats::Text do
     Prometheus::Client.config.data_store = Prometheus::Client::DataStores::Synchronized.new
   end
 
-  let(:registry) { Prometheus::Client::Registry.new }
+  let(:registry) { Prometheus::Client::Registry.instance }
 
   before do
     foo = registry.counter(:foo,

--- a/spec/prometheus/client/registry_spec.rb
+++ b/spec/prometheus/client/registry_spec.rb
@@ -4,7 +4,7 @@ require 'thread'
 require 'prometheus/client/registry'
 
 describe Prometheus::Client::Registry do
-  let(:registry) { Prometheus::Client::Registry.new }
+  let(:registry) { Prometheus::Client::Registry.instance }
 
   describe '.new' do
     it 'returns a new registry instance' do
@@ -13,6 +13,8 @@ describe Prometheus::Client::Registry do
   end
 
   describe '#register' do
+    let(:registry) { Prometheus::Client::Registry.clone.instance }
+
     it 'registers a new metric container and returns it' do
       metric = double(name: :test)
 
@@ -89,6 +91,8 @@ describe Prometheus::Client::Registry do
   end
 
   describe '#exist?' do
+    let(:registry) { Prometheus::Client::Registry.clone.instance }
+
     it 'returns true if a metric name has been registered' do
       registry.register(double(name: :test))
 
@@ -101,6 +105,8 @@ describe Prometheus::Client::Registry do
   end
 
   describe '#get' do
+    let(:registry) { Prometheus::Client::Registry.clone.instance }
+
     it 'returns a previously registered metric container' do
       registry.register(double(name: :test))
 

--- a/spec/prometheus/integration_spec.rb
+++ b/spec/prometheus/integration_spec.rb
@@ -5,15 +5,7 @@ require 'rack'
 require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
 
-API = Rack::Builder.new do
-  use Rack::Deflater
-  use Prometheus::Middleware::Collector
-  use Prometheus::Middleware::Exporter
-
-  map "/" do
-    run ->(_) { [200, {'Content-Type' => 'text/html'}, ['OK']] }
-  end
-end
+require_relative "../support/api"
 
 describe API do
   include Rack::Test::Methods

--- a/spec/prometheus/integration_spec.rb
+++ b/spec/prometheus/integration_spec.rb
@@ -1,0 +1,31 @@
+# encoding: UTF-8
+
+require 'rack/test'
+require 'rack'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+API = Rack::Builder.new do
+  use Rack::Deflater
+  use Prometheus::Middleware::Collector
+  use Prometheus::Middleware::Exporter
+
+  map "/" do
+    run ->(_) { [200, {'Content-Type' => 'text/html'}, ['OK']] }
+  end
+end
+
+describe API do
+  include Rack::Test::Methods
+
+  let(:app) { described_class }
+
+  context 'GET /metrics' do
+    it 'fails on the second request' do
+      get '/metrics'
+      expect { last_response }.not_to raise_error
+      expect { get '/metrics' }.not_to raise_error
+    end
+  end
+end
+

--- a/spec/prometheus/middleware/exporter_spec.rb
+++ b/spec/prometheus/middleware/exporter_spec.rb
@@ -7,7 +7,7 @@ describe Prometheus::Middleware::Exporter do
   include Rack::Test::Methods
 
   let(:registry) do
-    Prometheus::Client::Registry.new
+    Prometheus::Client::Registry.instance
   end
 
   let(:app) do

--- a/spec/prometheus/threaded_integration_spec.rb
+++ b/spec/prometheus/threaded_integration_spec.rb
@@ -6,15 +6,7 @@ require 'prometheus/middleware/collector'
 require 'prometheus/middleware/exporter'
 require "concurrent"
 
-API = Rack::Builder.new do
-  use Rack::Deflater
-  use Prometheus::Middleware::Collector
-  use Prometheus::Middleware::Exporter
-
-  map "/" do
-    run ->(_) { [200, {'Content-Type' => 'text/html'}, ['OK']] }
-  end
-end
+require_relative "../support/api"
 
 describe API do
   include Rack::Test::Methods
@@ -48,6 +40,7 @@ describe API do
       t4 = Thread.new do
         latch.wait
         res = get '/metrics'
+
         expect(res.body).not_to be_empty
       end
 

--- a/spec/prometheus/threaded_integration_spec.rb
+++ b/spec/prometheus/threaded_integration_spec.rb
@@ -27,26 +27,33 @@ describe API do
 
       t1 = Thread.new do
         latch.wait
-        get '/metrics'
+        res = get '/metrics'
+
+        expect(res.body).not_to be_empty
       end
 
       t2 = Thread.new do
         latch.wait
+        res = get '/metrics'
 
-        get '/metrics'
+        expect(res.body).not_to be_empty
       end
 
       t3 = Thread.new do
         latch.wait
+        res = get '/metrics'
+        expect(res.body).not_to be_empty
+      end
 
-        get '/metrics'
+      t4 = Thread.new do
+        latch.wait
+        res = get '/metrics'
+        expect(res.body).not_to be_empty
       end
 
       latch.count_down
 
-      [t1, t2, t3].each(&:join)
-
-      expect { last_response }.not_to raise_error
+      [t1, t2, t3, t4].each(&:join)
     end
   end
 end

--- a/spec/support/api.rb
+++ b/spec/support/api.rb
@@ -1,0 +1,13 @@
+require 'rack'
+
+API = Rack::Builder.new do
+  use Rack::Deflater
+  use Prometheus::Middleware::Collector
+  use Prometheus::Middleware::Exporter
+
+  map "/" do
+    run ->(_) { [200, {'Content-Type' => 'text/html'}, ['OK']] }
+  end
+end
+
+


### PR DESCRIPTION
# What does it fix #151 
There are two issues with the current implementation:
1. In the collector middleware
2. A design issue with the registry

I will go over them one by one

## The collector
https://github.com/prometheus/client_ruby/blob/80adc307f90d59f977324c3e5a38bcc9f980cb5f/lib/prometheus/middleware/collector.rb#L36-L37

These `init_*` methods get called every single time a request happens
https://github.com/prometheus/client_ruby/blob/b3bbe23ae8b9bdf3379699e310a8450a46efa1fe/lib/prometheus/middleware/collector.rb#L46-L47
As you can see, every request we try to register the default `http_*` metrics.
If you think this is not an issue with MRI, it is actually, it raises `AlreadyRegisteredError` with MRI
This is the spec https://github.com/prometheus/client_ruby/pull/153/commits/d4f4e3226cec8d6c42a704b222457c9702fccd83 that produces the bug.

### The fix
Check before adding the metric to the registry, if the metric is already there, use it, otherwise push the metric to the registry.
Here https://github.com/prometheus/client_ruby/pull/153/commits/fb4504e5aae5a22caf9fb2e8de129651ad641406 I introduce the `registry.get(metric)`

I think Daniel mentioned something regards symbols/strings. I would vote for strings, I can try and fix this too but it will be a breaking change if I understand correctly? maybe we can have a coercing method under the hood and warn about the deprecation or something.

## The registry
Turned out, in a multi-threaded world, two threads could race to register the metric, and bypass the `@registry.get(metric)` check. So one would register the metric and the other would raise `AlreadyRegisteredError`.
The way I see it if multiple threads try to register the same metric (with locking introduced), if the metric is registered, there should be no errors raised, just return the metric and use it to perform the preferred action.
Hence here https://github.com/prometheus/client_ruby/pull/153/commits/80adc307f90d59f977324c3e5a38bcc9f980cb5f I changed from rubt's mutex, to something more efficient for the use case.

The specs for thread safety was relying on the `raise` to make it thread-safe, for me, this design is more of a workaround. If the registry is thread-safe, it means only one metric will be written to the registry at all times.

## The registry again
I re-designed in the last commit the registry to be used as `singleton` object. This way we don't need the rather ~bad~ not thread safe memoization.


## Points to discuss
@dmagliola Please let me know how is the new design works, maybe I understand things wrongly, or my implementation has flaws. Also if you can put me in the loop while you discuss this with your team that would be great.