### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/lib/prometheus/client/version.rb
+++ b/lib/prometheus/client/version.rb
@@ -2,6 +2,6 @@
 
 module Prometheus
   module Client
-    VERSION = '0.10.0-alpha.2'
+    VERSION = '0.10.0'
   end
 end


### PR DESCRIPTION
What we've got now is pretty damn stable.

We've got stuff in the backlog, but there's no reason to delay promoting our current release from alpha to something proper.

Doing this has the nice property of our `README` lining up  with the library you get from `gem install`, which doesn't give you the alpha version unless you ask for it.

@dmagliola As we discussed at work. I'll follow up with the docs PR(s) - no need for them to coincide with a release! We can have a crack at the more interesting ones when I'm back if you fancy.