### PR TITLE
Remove dependency pins for unsupported Ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,13 @@ source 'https://rubygems.org'
 
 gemspec
 
-def ruby_version?(constraint)
-  Gem::Dependency.new('', constraint).match?('', RUBY_VERSION)
-end
-
 group :test do
   gem 'coveralls'
-  gem 'json', '< 2.0' if ruby_version?('< 2.0')
-  gem 'rack', '< 2.0' if ruby_version?('< 2.2.2')
+  gem 'json'
+  gem 'rack'
   gem 'rack-test'
   gem 'rake'
   gem 'rspec'
-  gem 'term-ansicolor', '< 1.4' if ruby_version?('< 2.0')
-  gem 'tins', '< 1.7' if ruby_version?('< 2.0')
+  gem 'term-ansicolor'
+  gem 'tins'
 end


### PR DESCRIPTION
Little bit of cleanup I thought I'd do since I spotted it.

Only impacts test dependencies anyway.