### PR TITLE
add DCO to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,5 @@ Prometheus uses GitHub to manage reviews of pull requests.
   on our [mailing list](https://groups.google.com/forum/?fromgroups#!forum/prometheus-developers).
   This will avoid unnecessary work and surely give you and us a good deal
   of inspiration.
+
+* Be sure to sign your commits off (per the [DCO](https://github.com/probot/dco#how-it-works)) by including `--signoff` as a parameter to your `git commit` commands.


### PR DESCRIPTION
I was caught off guard after being asked to sign off on the DCO because
it was not in the contribution guide.  Adding it here.