### PR TITLE
Add an easy way to define preset labels globally

### DIFF
--- a/lib/prometheus/client.rb
+++ b/lib/prometheus/client.rb
@@ -7,8 +7,8 @@ module Prometheus
   # Client is a ruby implementation for a Prometheus compatible client.
   module Client
     # Returns a default registry object
-    def self.registry
-      @registry ||= Registry.new
+    def self.registry(labels: [], preset_labels: {})
+      @registry ||= Registry.new(labels: labels, preset_labels: preset_labels)
     end
 
     def self.config

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -13,9 +13,11 @@ module Prometheus
     class Registry
       class AlreadyRegisteredError < StandardError; end
 
-      def initialize
+      def initialize(labels: [], preset_labels: {})
         @metrics = {}
         @mutex = Mutex.new
+        @labels = labels
+        @preset_labels = preset_labels
       end
 
       def register(metric)
@@ -40,24 +42,24 @@ module Prometheus
       def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Counter.new(name,
                              docstring: docstring,
-                             labels: labels,
-                             preset_labels: preset_labels,
+                             labels: @labels + labels,
+                             preset_labels: @preset_labels.merge(preset_labels),
                              store_settings: store_settings))
       end
 
       def summary(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Summary.new(name,
                              docstring: docstring,
-                             labels: labels,
-                             preset_labels: preset_labels,
+                             labels: @labels + labels,
+                             preset_labels: @preset_labels.merge(preset_labels),
                              store_settings: store_settings))
       end
 
       def gauge(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Gauge.new(name,
                            docstring: docstring,
-                           labels: labels,
-                           preset_labels: preset_labels,
+                           labels: @labels + labels,
+                           preset_labels: @preset_labels.merge(preset_labels),
                            store_settings: store_settings))
       end
 
@@ -66,8 +68,8 @@ module Prometheus
                     store_settings: {})
         register(Histogram.new(name,
                                docstring: docstring,
-                               labels: labels,
-                               preset_labels: preset_labels,
+                               labels: @labels + labels,
+                               preset_labels: @preset_labels.merge(preset_labels),
                                buckets: buckets,
                                store_settings: store_settings))
       end


### PR DESCRIPTION
Hi again,

With this change, I will be able to do the following:

```ruby
prometheus = Prometheus::Client.registry(labels: %i[app_version], preset_labels: { app_version: ENV["HEROKU_RELEASE_VERSION"] })
```

And easily see the version that my metrics were emitted by. I can now clearly see if behavior changed when the version changed, and the code will be pretty clean too.

I wish that I wouldn't need to set both `:labels` and `:preset_labels`.. It feels overly verbose. I almost think `preset_labels.keys` should be merged into `labels` automatically, but that would be a breaking change, so I didn't try to include it here.

I don't know if there are any philosophical objections to something like this, but I figured that I should throw it out there. Thanks!