### PR TITLE
Change prometheus command to use double-dash for flags

### DIFF
--- a/examples/rack/README.md
+++ b/examples/rack/README.md
@@ -23,7 +23,7 @@ output of `/metrics` and terminate.
 Start a Prometheus server with the provided config:
 
 ```bash
-prometheus -config.file ./prometheus.yml
+prometheus --config.file ./prometheus.yml
 ```
 
 In another terminal, start the application server:


### PR DESCRIPTION
This PR replaces the pre-2.0 style flag prefix (single dash) with the current double-dash flag prefix for the prometheus command in examples/rack/README.md

@dmagliola