### PR TITLE
observed value should be stored the bucket

### DIFF
--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -47,7 +47,7 @@ module Prometheus
       end
 
       def observe(value, labels: {})
-        bucket = buckets.find {|upper_limit| upper_limit > value  }
+        bucket = buckets.find {|upper_limit| upper_limit >= value  }
         bucket = "+Inf" if bucket.nil?
 
         base_label_set = label_set_for(labels)

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -140,10 +140,12 @@ describe Prometheus::Client::Histogram do
     it 'returns a hash of all recorded summaries' do
       histogram.observe(3, labels: { status: 'bar' })
       histogram.observe(6, labels: { status: 'foo' })
+      histogram.observe(10, labels: { status: 'baz' })
 
       expect(histogram.values).to eql(
         { status: 'bar' } => { "2.5" => 0.0, "5" => 1.0, "10" => 1.0, "+Inf" => 1.0, "sum" => 3.0 },
         { status: 'foo' } => { "2.5" => 0.0, "5" => 0.0, "10" => 1.0, "+Inf" => 1.0, "sum" => 6.0 },
+        { status: 'baz' } => { "2.5" => 0.0, "5" => 0.0, "10" => 1.0, "+Inf" => 1.0, "sum" => 10.0 },
       )
     end
   end


### PR DESCRIPTION
whose value is the same as the observed value

Seems to be working  in v0.9.0 
https://github.com/prometheus/client_ruby/blob/9bae72520e7fdadab983ddd2cd40832e37489793/lib/prometheus/client/histogram.rb#L29

which behavior is correct?