### PR TITLE
Add Gem & Bundler instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ through a HTTP interface. Intended to be used together with a
 
 ## Usage
 
+### Installation
+
+For a global installation run `gem install prometheus-client`.
+
+If you're using [Bundler](https://bundler.io/) add `gem "prometheus-client"` to your `Gemfile`.
+Make sure to run `bundle install` afterwards.
+
 ### Overview
 
 ```ruby


### PR DESCRIPTION
Attn: @dmagliola

Previously there was no mention of actually installing the gem, which is usually useful for a lot of more junior devs.
This PR just adds a few general lines making the name of the gem `prometheus-client` explicit and giving Gemfile and global installation examples.

Signed-off-by: Christopher Guess <cguess@gmail.com>