### PR TITLE
Add :labels for Prometheus::Middleware::Collector

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -1,8 +1,6 @@
 # encoding: UTF-8
-
 require 'benchmark'
 require 'prometheus/client'
-
 module Prometheus
   module Middleware
     # Collector is a Rack middleware that provides a sample implementation of a
@@ -14,48 +12,45 @@ module Prometheus
     # By default metrics all have the prefix "http_server". Set
     # `:metrics_prefix` to something else if you like.
     #
+    # Set :labels for custom labels that will be added to each metric.
+    # for example, set `:labels` {"env" : "production"}
+    #
     # The request counter metric is broken down by code, method and path.
     # The request duration metric is broken down by method and path.
     class Collector
       attr_reader :app, :registry
-
       def initialize(app, options = {})
         @app = app
         @registry = options[:registry] || Client.registry
         @metrics_prefix = options[:metrics_prefix] || 'http_server'
-
+        @labels = options[:labels] || {}
         init_request_metrics
         init_exception_metrics
       end
-
       def call(env) # :nodoc:
         trace(env) { @app.call(env) }
       end
-
       protected
-
       def init_request_metrics
         @requests = @registry.counter(
           :"#{@metrics_prefix}_requests_total",
           docstring:
             'The total number of HTTP requests handled by the Rack application.',
-          labels: %i[code method path]
+          labels: %i[code method path] + @labels.keys
         )
         @durations = @registry.histogram(
           :"#{@metrics_prefix}_request_duration_seconds",
           docstring: 'The HTTP response duration of the Rack application.',
-          labels: %i[method path]
+          labels: %i[method path] + @labels.keys
         )
       end
-
       def init_exception_metrics
         @exceptions = @registry.counter(
           :"#{@metrics_prefix}_exceptions_total",
           docstring: 'The total number of exceptions raised by the Rack application.',
-          labels: [:exception]
+          labels: [:exception] + @labels.keys
         )
       end
-
       def trace(env)
         response = nil
         duration = Benchmark.realtime { response = yield }
@@ -65,26 +60,22 @@ module Prometheus
         @exceptions.increment(labels: { exception: exception.class.name })
         raise
       end
-
       def record(env, code, duration)
         counter_labels = {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
           path:   strip_ids_from_path(env['PATH_INFO']),
         }
-
         duration_labels = {
           method: env['REQUEST_METHOD'].downcase,
           path:   strip_ids_from_path(env['PATH_INFO']),
         }
-
-        @requests.increment(labels: counter_labels)
-        @durations.observe(duration, labels: duration_labels)
+        @requests.increment(labels: counter_labels.merge(@labels))
+        @durations.observe(duration, labels: duration_labels.merge(@labels))
       rescue
         # TODO: log unexpected exception during request recording
         nil
       end
-
       def strip_ids_from_path(path)
         path
           .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -143,7 +143,7 @@ describe Prometheus::Middleware::Collector do
       )
     end
 
-    it 'provides metric with the custom label' do
+    it 'can find metrics with custom labels' do
       get '/foo'
       metric = :http_server_request_duration_seconds
       correct_labels = { method: 'get', path: '/foo', env: 'valid_env'}


### PR DESCRIPTION
This pull request makes it possible to pass a labels argument that will add default labels to each metric exposed using the collector middleware.
Usage example:
` 
config.middleware.use Prometheus::Middleware::Collector, { labels: { env: Rails.env } }
`