### PR TITLE
Add a method to clear the registry

### DIFF
--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -83,6 +83,10 @@ module Prometheus
       def metrics
         @metrics.values
       end
+
+      def clear
+        @metrics.clear
+      end
     end
   end
 end

--- a/spec/prometheus/client/registry_spec.rb
+++ b/spec/prometheus/client/registry_spec.rb
@@ -121,4 +121,14 @@ describe Prometheus::Client::Registry do
       expect(registry.get(:test)).to eql(nil)
     end
   end
+
+  describe '#clear' do
+    it 'clears the registry' do
+      registry.register(double(name: :test))
+
+      expect(registry.get(:test)).to_not be_nil
+      registry.clear
+      expect(registry.get(:test)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Clearing the registry is something we would typically do in development
and test environments.

For instance, in Rails apps, this method can be used when reloading
classes so that auto-loaded files that register Prometheus metrics can
be reloaded:

```rb
Rails.application.reloader.after_class_unload do
  Prometheus::Client.registry.clear
end
```

Not clearing the registry before classes are reloaded would result in
the registry raising an `AlreadyRegisteredError` when a file
registering a metric is reloaded.

Signed-off-by: Matthieu Prat <matthieuprat@gocardless.com>