### PR TITLE
Remove call to deprecated `URI.escape`

### DIFF
--- a/lib/prometheus/client/push.rb
+++ b/lib/prometheus/client/push.rb
@@ -66,9 +66,9 @@ module Prometheus
 
       def build_path(job, instance)
         if instance
-          format(INSTANCE_PATH, URI.escape(job), URI.escape(instance))
+          format(INSTANCE_PATH, CGI::escape(job), CGI::escape(instance))
         else
-          format(PATH, URI.escape(job))
+          format(PATH, CGI::escape(job))
         end
       end
 

--- a/spec/prometheus/client/push_spec.rb
+++ b/spec/prometheus/client/push_spec.rb
@@ -73,7 +73,7 @@ describe Prometheus::Client::Push do
     it 'escapes non-URL characters' do
       push = Prometheus::Client::Push.new('bar job', 'foo <my instance>')
 
-      expected = '/metrics/job/bar%20job/instance/foo%20%3Cmy%20instance%3E'
+      expected = '/metrics/job/bar+job/instance/foo+%3Cmy+instance%3E'
       expect(push.path).to eql(expected)
     end
   end


### PR DESCRIPTION
This method has been deprecated for a while, and it gives us warnings in Ruby 2.7