### PR TITLE
Fix Ruby Warnings

### DIFF
--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -74,6 +74,7 @@ module Prometheus
             @metric_name = metric_name
             @store_settings = store_settings
             @values_aggregation_mode = metric_settings[:aggregation]
+            @store_opened_by_pid = nil
 
             @lock = Monitor.new
           end

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -89,15 +89,15 @@ module Prometheus
 
       # Returns all label sets with their values expressed as hashes with their buckets
       def values
-        v = @store.all_values
+        values = @store.all_values
 
-        result = v.each_with_object({}) do |(label_set, v), acc|
+        result = values.each_with_object({}) do |(label_set, v), acc|
           actual_label_set = label_set.reject{|l| l == :le }
           acc[actual_label_set] ||= @buckets.map{|b| [b.to_s, 0.0]}.to_h
           acc[actual_label_set][label_set[:le].to_s] = v
         end
 
-        result.each do |(label_set, v)|
+        result.each do |(_label_set, v)|
           accumulate_buckets(v)
         end
       end

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -29,16 +29,17 @@ module Prometheus
         @docstring = docstring
         @preset_labels = stringify_values(preset_labels)
 
+        @all_labels_preset = false
+        if preset_labels.keys.length == labels.length
+          @validator.validate_labelset!(preset_labels)
+          @all_labels_preset = true
+        end
+
         @store = Prometheus::Client.config.data_store.for_metric(
           name,
           metric_type: type,
           metric_settings: store_settings
         )
-
-        if preset_labels.keys.length == labels.length
-          @validator.validate_labelset!(preset_labels)
-          @all_labels_preset = true
-        end
       end
 
       # Returns the value for the given label set

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -36,9 +36,9 @@ module Prometheus
 
       # Returns all label sets with their values expressed as hashes with their sum/count
       def values
-        v = @store.all_values
+        values = @store.all_values
 
-        v.each_with_object({}) do |(label_set, v), acc|
+        values.each_with_object({}) do |(label_set, v), acc|
           actual_label_set = label_set.reject{|l| l == :quantile }
           acc[actual_label_set] ||= { "count" => 0.0, "sum" => 0.0 }
           acc[actual_label_set][label_set[:quantile]] = v


### PR DESCRIPTION
Our tests are running without outputting warnings, so we don't see a number
of things Ruby was warning us about.

All these code changes are effectively a NOOP.