### PR TITLE
Turn on Ruby Warnings on Test Suite

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@
 require 'simplecov'
 require 'coveralls'
 
+RSpec.configure do |c|
+  c.warnings = true
+end
+
 SimpleCov.formatter =
   if ENV['CI']
     Coveralls::SimpleCov::Formatter


### PR DESCRIPTION
We were running our tests with warnings off, which meant we didn't notice
a bunch of warnings we were emitting.