### PR TITLE
Include SCRIPT_NAME when determining path

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -68,20 +68,10 @@ module Prometheus
 
       def record(env, code, duration)
         path = env[Rack::SCRIPT_NAME] + env[Rack::PATH_INFO]
+        shared_labels = { method: env['REQUEST_METHOD'].downcase, path: strip_ids_from_path(path) }
 
-        counter_labels = {
-          code:   code,
-          method: env['REQUEST_METHOD'].downcase,
-          path:   strip_ids_from_path(path),
-        }
-
-        duration_labels = {
-          method: env['REQUEST_METHOD'].downcase,
-          path:   strip_ids_from_path(path),
-        }
-
-        @requests.increment(labels: counter_labels)
-        @durations.observe(duration, labels: duration_labels)
+        @requests.increment(labels: { code: code, **shared_labels })
+        @durations.observe(duration, labels: shared_labels)
       rescue
         # TODO: log unexpected exception during request recording
         nil

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -67,15 +67,17 @@ module Prometheus
       end
 
       def record(env, code, duration)
+        path = env[Rack::SCRIPT_NAME] + env[Rack::PATH_INFO]
+
         counter_labels = {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
-          path:   strip_ids_from_path(env['PATH_INFO']),
+          path:   strip_ids_from_path(path),
         }
 
         duration_labels = {
           method: env['REQUEST_METHOD'].downcase,
-          path:   strip_ids_from_path(env['PATH_INFO']),
+          path:   strip_ids_from_path(path),
         }
 
         @requests.increment(labels: counter_labels)


### PR DESCRIPTION
When determining the path for a request, `Rack::Request` prefixes the `SCRIPT_NAME`, [as seen here][1]. This makes sure the relative path is included. At work, we use [Iodine](https://github.com/boazsegev/iodine) and Turbolinks, and without this patch most of our requests paths in Prometheus are `""`.  This patch fixes that.

[1]: https://github.com/rack/rack/blob/294fd239a71aab805877790f0a92ee3c72e67d79/lib/rack/request.rb#L512