### PR TITLE
Make all registry methods thread safe

### DIFF
--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -22,7 +22,7 @@ module Prometheus
         name = metric.name
 
         @mutex.synchronize do
-          if exist?(name.to_sym)
+          if @metrics.key?(name.to_sym)
             raise AlreadyRegisteredError, "#{name} has already been registered"
           end
           @metrics[name.to_sym] = metric
@@ -73,15 +73,15 @@ module Prometheus
       end
 
       def exist?(name)
-        @metrics.key?(name)
+        @mutex.synchronize { @metrics.key?(name) }
       end
 
       def get(name)
-        @metrics[name.to_sym]
+        @mutex.synchronize { @metrics[name.to_sym] }
       end
 
       def metrics
-        @metrics.values
+        @mutex.synchronize { @metrics.values }
       end
     end
   end

--- a/spec/prometheus/client/registry_spec.rb
+++ b/spec/prometheus/client/registry_spec.rb
@@ -33,10 +33,6 @@ describe Prometheus::Client::Registry do
       mutex = Mutex.new
       containers = []
 
-      def registry.exist?(*args)
-        super.tap { sleep(0.01) }
-      end
-
       Array.new(5) do
         Thread.new do
           result = begin


### PR DESCRIPTION
The registry is backed by a Hash, which is not guaranteed to be thread
safe on all interpreters. For peace of mind, this change synchronizes
all accesses to the metrics hash.

Another option would have been to use a [thread-safe Hash][1] instead of
a Hash but this would have meant adding Ruby Concurrent as a
dependency, which I'm assuming we don't want.

Ref: https://github.com/prometheus/client_ruby/pull/184#discussion_r406038191

[1]: https://github.com/ruby-concurrency/concurrent-ruby/blob/v1.1.7/lib/concurrent-ruby/concurrent/hash.rb