### PR TITLE
Takes into account the SCRIPT_NAME in path

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -67,15 +67,16 @@ module Prometheus
       end
 
       def record(env, code, duration)
+        path = [env["SCRIPT_NAME"], env['PATH_INFO']].join
         counter_labels = {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
-          path:   strip_ids_from_path(env['PATH_INFO']),
+          path:   strip_ids_from_path(path),
         }
 
         duration_labels = {
           method: env['REQUEST_METHOD'].downcase,
-          path:   strip_ids_from_path(env['PATH_INFO']),
+          path:   strip_ids_from_path(path),
         }
 
         @requests.increment(labels: counter_labels)


### PR DESCRIPTION
Hi! Not sure that this is correct, but: 
1. We have lost the path using mountable engines (twirp, grape) 
2. It looks like the RFC says that this is correct: [SCRIPT_NAME](https://tools.ietf.org/html/rfc3875#section-4.1.13), [PATH_NFO](https://tools.ietf.org/html/rfc3875#section-4.1.5)
3. https://github.com/rack/rack/blob/master/lib/rack/handler/webrick.rb#L92

Sorry without tests for now. Want to hear your opinion.