### PR TITLE
let signed_id of ActiveStorge::Blob be striped from as an id

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -91,6 +91,7 @@ module Prometheus
         path
           .gsub(%r{/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(/|$)}, '/:uuid\\1')
           .gsub(%r{/\d+(/|$)}, '/:id\\1')
+          .gsub(%r{/[0-9a-zA-Z=]+--[0-9a-f]+(/|$)}, '/:signed_id\\1')
       end
     end
   end


### PR DESCRIPTION
Strip signed_id of [Rails ActiveStorge::Blob](https://api.rubyonrails.org/v6.1.0/classes/ActiveStorage/Blob.html) by default like normal IDs and UUIDs