### PR TITLE
Add missing 'cgi' require in push client

### DIFF
--- a/lib/prometheus/client/push.rb
+++ b/lib/prometheus/client/push.rb
@@ -3,6 +3,7 @@
 require 'thread'
 require 'net/http'
 require 'uri'
+require 'cgi'
 
 require 'prometheus/client'
 require 'prometheus/client/formats/text'


### PR DESCRIPTION
Fixes #202

Tested the fix on 2.7.2 with the push gateway running locally and it seems to do the trick:

```
sinjo@coin:~/projects/client_ruby$ bx irb
irb(main):001:0> require "prometheus/client/push"
=> true
irb(main):002:0> registry = Prometheus::Client.registry
=> #<Prometheus::Client::Registry:0x00005620d98717e8 @metrics={}, @mutex=#<Thread::Mutex:0x00005620d9871658>>
irb(main):003:0> Prometheus::Client::Push.new('test-job').add(registry)
=> #<Net::HTTPOK 200 OK readbody=true>
```