### PR TITLE
Enable configuring `Net::HTTP` timeouts

### DIFF
--- a/lib/prometheus/client/push.rb
+++ b/lib/prometheus/client/push.rb
@@ -20,7 +20,7 @@ module Prometheus
 
       attr_reader :job, :instance, :gateway, :path
 
-      def initialize(job, instance = nil, gateway = nil)
+      def initialize(job, instance = nil, gateway = nil, **kwargs)
         @mutex = Mutex.new
         @job = job
         @instance = instance
@@ -30,6 +30,8 @@ module Prometheus
 
         @http = Net::HTTP.new(@uri.host, @uri.port)
         @http.use_ssl = (@uri.scheme == 'https')
+        @http.open_timeout = kwargs[:open_timeout] if kwargs[:open_timeout]
+        @http.read_timeout = kwargs[:read_timeout] if kwargs[:read_timeout]
       end
 
       def add(registry)

--- a/spec/prometheus/client/push_spec.rb
+++ b/spec/prometheus/client/push_spec.rb
@@ -5,7 +5,7 @@ require 'prometheus/client/push'
 describe Prometheus::Client::Push do
   let(:gateway) { 'http://localhost:9091' }
   let(:registry) { Prometheus::Client.registry }
-  let(:push) { Prometheus::Client::Push.new('test-job', nil, gateway) }
+  let(:push) { Prometheus::Client::Push.new('test-job', nil, gateway, open_timeout: 5, read_timeout: 30) }
 
   describe '.new' do
     it 'returns a new push instance' do
@@ -91,6 +91,8 @@ describe Prometheus::Client::Push do
 
       http = double(:http)
       expect(http).to receive(:use_ssl=).with(false)
+      expect(http).to receive(:open_timeout=).with(5)
+      expect(http).to receive(:read_timeout=).with(30)
       expect(http).to receive(:request).with(request)
       expect(Net::HTTP).to receive(:new).with('localhost', 9091).and_return(http)
 
@@ -104,6 +106,8 @@ describe Prometheus::Client::Push do
 
       http = double(:http)
       expect(http).to receive(:use_ssl=).with(false)
+      expect(http).to receive(:open_timeout=).with(5)
+      expect(http).to receive(:read_timeout=).with(30)
       expect(http).to receive(:request).with(request)
       expect(Net::HTTP).to receive(:new).with('localhost', 9091).and_return(http)
 
@@ -121,6 +125,8 @@ describe Prometheus::Client::Push do
 
         http = double(:http)
         expect(http).to receive(:use_ssl=).with(true)
+        expect(http).to receive(:open_timeout=).with(5)
+        expect(http).to receive(:read_timeout=).with(30)
         expect(http).to receive(:request).with(request)
         expect(Net::HTTP).to receive(:new).with('localhost', 9091).and_return(http)
 
@@ -140,6 +146,8 @@ describe Prometheus::Client::Push do
 
         http = double(:http)
         expect(http).to receive(:use_ssl=).with(true)
+        expect(http).to receive(:open_timeout=).with(5)
+        expect(http).to receive(:read_timeout=).with(30)
         expect(http).to receive(:request).with(request)
         expect(Net::HTTP).to receive(:new).with('localhost', 9091).and_return(http)
 


### PR DESCRIPTION
👋 !

We recently had an issue in our infrastructure where a Push Gateway was getting overloaded due to too much metric cardinality in the time series data that we were sending. We remedied this issue and things are well, but part of the way we noticed was that these pushes were happening in our job workers, which we have a lot of timing instrumentation around.

Digging in a bit further, we noticed that a huge number jobs were taking 60 seconds to complete, when they are normally much (sub-second) faster. We realized that this was due to our calls out to the push gateway, which would eventually time out. We wanted to be able to set the push timeout to be significantly lower (1-5 seconds) so that we can fail fast and avoid eating into our job capacity if there is ever an issue with our gateways again.

Looking at the [Ruby documentation for Net::HTTP](https://ruby-doc.org/stdlib-2.7.2/libdoc/net/http/rdoc/Net/HTTP.html), both `read_timeout` and `open_timeout` have a default timeout of 60 seconds:

```
If the HTTP object cannot read data in this many seconds, it raises a Net::ReadTimeout exception. The default value is 60 seconds.
```

```
If the HTTP object cannot open a connection in this many seconds, it raises a Net::OpenTimeout exception. The default value is 60 seconds.
```

This PR allows a user to pass through the `read_timeout` and `open_timeout` in the initialization of a new `Push` class, but retains the defaults otherwise. I am not in love with using `**kwargs`, and am open to other methods of configuring this value (and happy to implement them myself). I do believe that it's important to give the user control of these values however. 

Thanks! 