### PR TITLE
Update CHANGELOG in preparation for 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # CHANGELOG
 
+# Upcoming 3.0.0 / 2021-??-?? (not released yet, these are the merged PRs we'll release)
+
+This new major version includes some breaking changes. They should be reasonably easy to
+adapt to, but please read the details below:
+
+## Breaking changes
+
+- [#206](https://github.com/prometheus/client_ruby/pull/206) Include SCRIPT_NAME when 
+    determining path in Collector:  
+    When determining the path for a request, Rack::Request prefixes the
+    SCRIPT_NAME. This was a problem with our code when using mountable engines,
+    where the engine part of the path gets lost. This patch fixes that to include SCRIPT_NAME as part of the path.
+    
+    **This may be a breaking change**. Labels may change in existing metrics.  
+
+- [#209](https://github.com/prometheus/client_ruby/pull/209) Automatically initialize metrics
+    without labels.  
+    Following the [Prometheus Best Practices](https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics), 
+    client libraries are expected to automatically export a 0 value when declaring a metric 
+    that has no labels.  
+    We missed this recommendation in the past, and this wasn't happening. Starting from this 
+    version, all metrics without labels will be immediately exported with `0` value, without
+    need for an increment / observation. 
+    
+    **This may be a breaking change**. Depending on your particular metrics, this may
+    result in a significant increase to the number of time series being exported. We 
+    recommend you test this and make sure it doesn't cause problems.  
+
+- [#220](https://github.com/prometheus/client_ruby/pull/220) Improvements to PushGateway client:  
+    - The `job` parameter is now mandatory when instantiating `Prometheus::Client::Push` 
+        and will raise `ArgumentError` if not specified, or if `nil` or an empty string/object
+        are passed.
+    - The `Prometheus::Client::Push` initializer now takes keyword arguments.
+    - We now correctly handle an empty value for `instance` when generating the path to
+        the PushGateway. 
+    - Fixed URI escaping of spaces in the path to PushGateway. In the past, spaces were
+        being encoded as `+` instead of `%20`, which is invalid.
+        
+    **This is a breaking change if you use Pushgateway**. You will need to update your
+    code to pass keyword arguments to the `Prometheus::Client::Push` initializer.
+    
+
+# 2.2.0 / 2021-06-?? <-- TODO: update this date when we merge this and cut the new version
+
+## New Features
+
+- [#199](https://github.com/prometheus/client_ruby/pull/199) Add `port` filtering option
+    to Exporter middleware.  
+    You can now specify a `port` when adding `Prometheus::Middleware::Exporter` to your
+    middleware chain, and metrics will only be exported if the `/metrics` request comes
+    through that port.
+
+- [#222](https://github.com/prometheus/client_ruby/pull/222) Enable configuring `Net::HTTP` 
+    timeouts for PushGateway calls.  
+    You can now specify `open_timeout` and `read_timeout` when instantiating 
+    `Prometheus::Client::Push`, to control these timeouts.
+
+## Code improvements and bug fixes
+
+- [#201](https://github.com/prometheus/client_ruby/pull/201) Make all registry methods 
+    thread safe.
+
+- [#227](https://github.com/prometheus/client_ruby/pull/227) Fix `with_labels` bug that 
+    made it completely non-functional, and occasionally resulted in `DirectFileStore` file 
+    corruption.
+
+
 # 2.1.0 / 2020-06-29
 
 ## New Features


### PR DESCRIPTION
Includes the changes in `master` that we'll release in `2.2.0`, and
the ones that we can't because of breaking changes, which we'll release
in `3.0.0`

--------

I'm proposing to release a new version with the bug fixes and backwards-compatible improvements we've introduced (which we should have released ages ago, but life), including the not-yet-merged fix to `with_labels` in #227.

Since `master` has many non-releasable changes, I've created branch `v2.2_release`, which forks off of `2.1.0` and has the relevant commits cherry-picked into it.

[Comparison between 2.2.0 (cherry-picked commits) vs 2.1.0](https://github.com/prometheus/client_ruby/compare/v2.1.0...v2.2_release?expand=1)

Once we finish the changes to PushGateway, we'll release v3.0 with what's in `master` right now.

--------

NOTE: Do not merge this yet. If @Sinjo agrees with this approach, I'll update this README with the correct, date, merge, and add a new release tag in the `v2.2_release` branch