### PR TITLE
Validate label names

### DIFF
--- a/lib/prometheus/client/label_set_validator.rb
+++ b/lib/prometheus/client/label_set_validator.rb
@@ -7,6 +7,7 @@ module Prometheus
     class LabelSetValidator
       # TODO: we might allow setting :instance in the future
       BASE_RESERVED_LABELS = [:job, :instance, :pid].freeze
+      LABEL_NAME_REGEX = /\A[a-zA-Z_][a-zA-Z0-9_]*\Z/
 
       class LabelSetError < StandardError; end
       class InvalidLabelSetError < LabelSetError; end
@@ -59,9 +60,15 @@ module Prometheus
       end
 
       def validate_name(key)
-        return true unless key.to_s.start_with?('__')
+        if key.to_s.start_with?('__')
+          raise ReservedLabelError, "label #{key} must not start with __"
+        end
 
-        raise ReservedLabelError, "label #{key} must not start with __"
+        unless key.to_s =~ LABEL_NAME_REGEX
+          raise InvalidLabelError, "label name must match /#{LABEL_NAME_REGEX}/"
+        end
+
+        true
       end
 
       def validate_reserved_key(key)

--- a/spec/prometheus/client/label_set_validator_spec.rb
+++ b/spec/prometheus/client/label_set_validator_spec.rb
@@ -18,7 +18,7 @@ describe Prometheus::Client::LabelSetValidator do
       expect(validator.validate_symbols!(version: 'alpha')).to eql(true)
     end
 
-    it 'raises Invaliddescribed_classError if a label set is not a hash' do
+    it 'raises InvalidLabelSetError if a label set is not a hash' do
       expect do
         validator.validate_symbols!('invalid')
       end.to raise_exception invalid

--- a/spec/prometheus/client/label_set_validator_spec.rb
+++ b/spec/prometheus/client/label_set_validator_spec.rb
@@ -36,6 +36,12 @@ describe Prometheus::Client::LabelSetValidator do
       end.to raise_exception(described_class::ReservedLabelError)
     end
 
+    it 'raises InvalidLabelError if a label key contains invalid characters' do
+      expect do
+        validator.validate_symbols!(:@foo => 'key')
+      end.to raise_exception(described_class::InvalidLabelError)
+    end
+
     it 'raises ReservedLabelError if a label key is reserved' do
       [:job, :instance, :pid].each do |label|
         expect do


### PR DESCRIPTION
Up to now, we've only been performing limited validation of label names.
This commit validates that the characters use match the regex
`/\A[a-zA-Z_][a-zA-Z0-9_]*\Z/` as specified by:

https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

---

I ran into this while working on #234 for #186, but thought I'd separate it out into its own PR.

It's technically a breaking change, but I can't imagine Prometheus would have been happy scraping labels with these names to begin with. On top of that, our master branch already has breaking changes on it for the 3.0 release, so I figure one more doesn't hurt.