### PR TITLE
Update Ruby versions used in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ workflows:
         matrix:
           parameters:
             ruby_image:
-            - cimg/ruby:2.5
             - cimg/ruby:2.6
             - cimg/ruby:2.7
             - cimg/ruby:3.0
+            - cimg/ruby:3.1
             - circleci/jruby:9.1
             - circleci/jruby:9.2


### PR DESCRIPTION
Ruby 2.5 dropped out of support at the end of March 2021, and Ruby 3.1 was released on Christmas Day.