### PR TITLE
Replace Coveralls with SimpleCov

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'coveralls'
+  gem 'simplecov'
   gem 'json'
   gem 'rack'
   gem 'rack-test'

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ through a HTTP interface. Intended to be used together with a
 
 [![Gem Version][4]](http://badge.fury.io/rb/prometheus-client)
 [![Build Status][3]](https://circleci.com/gh/prometheus/client_ruby/tree/master.svg?style=svg)
-[![Coverage Status][7]](https://coveralls.io/r/prometheus/client_ruby)
 
 ## Usage
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,11 @@
 # encoding: UTF-8
 
 require 'simplecov'
-require 'coveralls'
 
 RSpec.configure do |c|
   c.warnings = true
 end
 
-SimpleCov.formatter =
-  if ENV['CI']
-    Coveralls::SimpleCov::Formatter
-  else
-    SimpleCov::Formatter::HTMLFormatter
-  end
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 
 SimpleCov.start


### PR DESCRIPTION
We've been having errors in CI from Coveralls, when trying to upload results.
(As mentioned in [this comment](https://github.com/prometheus/client_ruby/pull/230#issuecomment-864561231))

This error seems to be because our coveralls gem is pretty old and abandoned,
and probably using a TLS version that is no longer supported.

(Reference: https://github.com/lemurheavy/coveralls-ruby/issues/163)

One option recommended in that issue is to switch to a different `coveralls-ruby-reborn` gem.

However, given that we only use `coveralls` to upload results to the cloud,
only so we can have a badge in our README reporting 100%, in the interest of
security, I think i'd rather get rid of `coveralls` altogether, and use
`simplecov` directly instead, which reports the coverage when running the
tests and doesn't upload them anywhere.