### PR TITLE
Fix license name in gemspec

### DIFF
--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors           = ['Ben Kochie', 'Chris Sinjakli', 'Daniel Magliola']
   s.email             = ['superq@gmail.com', 'chris@sinjakli.co.uk', 'dmagliola@crystalgears.com']
   s.homepage          = 'https://github.com/prometheus/client_ruby'
-  s.license           = 'Apache 2.0'
+  s.license           = 'Apache-2.0'
 
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']


### PR DESCRIPTION
Previously, we had the license name set to "Apache 2.0", which doesn't
conform to the entry in the list that `gem` validates against
(https://spdx.org/licenses/).

This commit replaces the space with a hyphen so that we match the format
expected by `gem`, and don't get this warning when we build the gem:

> WARNING:  license value 'Apache 2.0' is invalid.  Use a license
> identifier from http://spdx.org/licenses or 'Nonstandard' for a
> nonstandard license. Did you mean 'Apache-2.0'?