### PR TITLE
Replace references to `master` branch with `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ This version contains a single - sadly breaking - change.
 
     If you want the behaviour from 3.0.0 - or any custom path label generation you'd
     prefer - we've updated [our collector middleware
-    documentation](https://github.com/prometheus/client_ruby/blob/master/examples/rack/README.md#collector).
+    documentation](https://github.com/prometheus/client_ruby/blob/v4.0.0/examples/rack/README.md#collector).
 
     **This may be a breaking change**. Labels may change in existing metrics.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ through a HTTP interface. Intended to be used together with a
 [Prometheus server][1].
 
 [![Gem Version][4]](http://badge.fury.io/rb/prometheus-client)
-[![Build Status][3]](https://circleci.com/gh/prometheus/client_ruby/tree/master.svg?style=svg)
+[![Build Status][3]](https://circleci.com/gh/prometheus/client_ruby/tree/main.svg?style=svg)
 
 ## Usage
 
@@ -504,9 +504,8 @@ rake
 
 [1]: https://github.com/prometheus/prometheus
 [2]: http://rack.github.io/
-[3]: https://secure.travis-ci.org/prometheus/client_ruby.svg?branch=master
+[3]: https://circleci.com/gh/prometheus/client_ruby/tree/main.svg?style=svg
 [4]: https://badge.fury.io/rb/prometheus-client.svg
-[7]: https://coveralls.io/repos/prometheus/client_ruby/badge.svg?branch=master
 [8]: https://github.com/prometheus/pushgateway
 [9]: lib/prometheus/middleware/exporter.rb
 [10]: lib/prometheus/middleware/collector.rb


### PR DESCRIPTION
Other parts of the Prometheus project (namely the Prometheus server repo
itself, which sets a lot of norms for everything else) have already
adopted this rename, so we should follow suit.

This commit will need to be merged in tandem with a main branch name
change on GitHub, and possibly some reconfiguration in the repo settings
in CircleCI.