### PR TITLE
Include LICENSE in gem

### DIFF
--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage          = 'https://github.com/prometheus/client_ruby'
   s.license           = 'Apache-2.0'
 
-  s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
+  s.files             = %w(README.md LICENSE) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
 
   s.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
This includes the LICENSE source in the built and released gem and further allows downstream packaging (e.g. RPM / deb) to include the official license file in the distributed source.