### PR TITLE
Add JRuby 9.3 to the build matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,3 +30,4 @@ workflows:
             - cimg/ruby:3.1
             - circleci/jruby:9.1
             - circleci/jruby:9.2
+            - circleci/jruby:9.3


### PR DESCRIPTION
I don't really follow JRuby any more, so this release passed me by, but
I figure it's worth adding to our build matrix.