### PR TITLE
Allow Interpolated symbols for metric name

### DIFF
--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -90,8 +90,8 @@ module Prometheus
         unless name.is_a?(Symbol)
           raise ArgumentError, 'metric name must be a symbol'
         end
-        unless name.to_s =~ /\A[a-zA-Z_:][a-zA-Z0-9_:]*\Z/
-          msg = 'metric name must match /[a-zA-Z_:][a-zA-Z0-9_:]*/'
+        unless name.to_s =~ /\A[a-zA-Z_:][a-zA-Z0-9_:$&#"":{}]*\Z/
+          msg = 'metric name must match /[a-zA-Z_:][a-zA-Z0-9_:$&#"":{}]*/'
           raise ArgumentError, msg
         end
       end


### PR DESCRIPTION
### Overview

The current implementation doesn't allow the use of interpolated symbols. On a use case where I'd like to dynamically generate different metric names via Ruby symbol interpolating i.e: `:"test_#{test_var}"`, is currently not possible, therefore, proposing this change.

For instance, ideally the following symbol definition should be welcomed as a metric name `:"metric_name_for_#{service_name}"` or even `"metric_name_for_#{service_name}".to_sym`, however, it returns ``prometheus-client-2.1.0/lib/prometheus/client/metric.rb:80:in `validate_name': metric name must match /[a-zA-Z_:][a-zA-Z0-9_:]*/ (ArgumentError)``