### PR TITLE
Use lowercase response headers in Rack example

### DIFF
--- a/examples/rack/config.ru
+++ b/examples/rack/config.ru
@@ -11,9 +11,9 @@ srand
 app = lambda do |_|
   case rand
   when 0..0.8
-    [200, { 'Content-Type' => 'text/html' }, ['OK']]
+    [200, { 'content-type' => 'text/html' }, ['OK']]
   when 0.8..0.95
-    [404, { 'Content-Type' => 'text/html' }, ['Not Found']]
+    [404, { 'content-type' => 'text/html' }, ['Not Found']]
   else
     raise NoMethodError, 'It is a bug!'
   end


### PR DESCRIPTION
Because HTTP/2 requires that headers are sent in lowercase, Rack has started validating that no header contains an uppercase letter.

We were setting uppercase headers as that was a common convention in HTTP/1.1, where they were interpreted in a case-insensitive fashion.

This change makes us compatible with Rack 3.0 without breaking compatibiility for older versions (not that it would matter for this example code).

---

Fixes #267