### PR TITLE
Rack run example fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ run ->(_) { [200, {'content-type' => 'text/html'}, ['OK']] }
 ```
 
 Start the server and have a look at the metrics endpoint:
-[http://localhost:5000/metrics](http://localhost:5000/metrics).
+[http://localhost:5123/metrics](http://localhost:5123/metrics).
 
 For further instructions and other scripts to get started, have a look at the
 integrated [example application](examples/rack/README.md).

--- a/examples/rack/README.md
+++ b/examples/rack/README.md
@@ -33,8 +33,8 @@ bundle install
 bundle exec unicorn -c ./unicorn.conf
 ```
 
-You can now open the [example app](http://localhost:5000/) and its [metrics
-page](http://localhost:5000/metrics) to inspect the output. The running
+You can now open the [example app](http://localhost:5123/) and its [metrics
+page](http://localhost:5123/metrics) to inspect the output. The running
 Prometheus server can be used to [play around with the metrics][rate-query].
 
 [rate-query]: http://localhost:9090/graph#%5B%7B%22range_input%22%3A%221h%22%2C%22expr%22%3A%22rate(http_server_requests_total%5B1m%5D)%22%2C%22tab%22%3A0%7D%5D

--- a/examples/rack/prometheus.yml
+++ b/examples/rack/prometheus.yml
@@ -10,4 +10,4 @@ scrape_configs:
   - job_name: "rack-example"
     static_configs:
       - targets:
-        - "localhost:5000"
+        - "localhost:5123"

--- a/examples/rack/run
+++ b/examples/rack/run
@@ -24,7 +24,7 @@ if ! installed vegeta; then
 	go install github.com/tsenart/vegeta@latest # newer versions of Go
 fi
 
-PORT=5000
+PORT=5123
 URL=http://127.0.0.1:${PORT}/
 
 log "starting example server"

--- a/examples/rack/run
+++ b/examples/rack/run
@@ -20,8 +20,8 @@ if ! installed vegeta; then
 		fatal "Could not find go. Either run the examples manually or install"
 	fi
 
-	go get github.com/tsenart/vegeta # older versions of Go
-	go install github.com/tsenart/vegeta@latest # newer versions of Go
+	go get github.com/tsenart/vegeta # versions of Go < 1.18
+	go install github.com/tsenart/vegeta@latest # versions of Go >= 1.18
 fi
 
 PORT=5123

--- a/examples/rack/run
+++ b/examples/rack/run
@@ -20,8 +20,8 @@ if ! installed vegeta; then
 		fatal "Could not find go. Either run the examples manually or install"
 	fi
 
-	go get github.com/tsenart/vegeta
-	go install github.com/tsenart/vegeta
+	go get github.com/tsenart/vegeta # older versions of Go
+	go install github.com/tsenart/vegeta@latest # newer versions of Go
 fi
 
 PORT=5000

--- a/examples/rack/unicorn.conf
+++ b/examples/rack/unicorn.conf
@@ -1,3 +1,3 @@
-listen 5000
+listen 5123
 worker_processes 1
 preload_app true


### PR DESCRIPTION
The example seems to be broken for some time. Here are the list of things fixed:

- [x] Port used replaced from 5000 to 5123 since Apple took port 5000 for Airplay
- [x] In newer versions of Go we should use `go install` rather than `go get` to install binaries