### PR TITLE
Using lowercase for HTTP headers to make it compatible with HTTP/2 and Rack v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ use Rack::Deflater
 use Prometheus::Middleware::Collector
 use Prometheus::Middleware::Exporter
 
-run ->(_) { [200, {'Content-Type' => 'text/html'}, ['OK']] }
+run ->(_) { [200, {'content-type' => 'text/html'}, ['OK']] }
 ```
 
 Start the server and have a look at the metrics endpoint:

--- a/lib/prometheus/middleware/exporter.rb
+++ b/lib/prometheus/middleware/exporter.rb
@@ -66,7 +66,7 @@ module Prometheus
       def respond_with(format)
         [
           200,
-          { 'Content-Type' => format::CONTENT_TYPE },
+          { 'content-type' => format::CONTENT_TYPE },
           [format.marshal(@registry)],
         ]
       end
@@ -76,7 +76,7 @@ module Prometheus
 
         [
           406,
-          { 'Content-Type' => 'text/plain' },
+          { 'content-type' => 'text/plain' },
           ["Supported media types: #{types.join(', ')}"],
         ]
       end

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -16,7 +16,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   let(:original_app) do
-    ->(_) { [200, { 'Content-Type' => 'text/html' }, ['OK']] }
+    ->(_) { [200, { 'content-type' => 'text/html' }, ['OK']] }
   end
 
   let!(:app) do
@@ -128,7 +128,7 @@ describe Prometheus::Middleware::Collector do
       lambda do |env|
         raise dummy_error if env['PATH_INFO'] == '/broken'
 
-        [200, { 'Content-Type' => 'text/html' }, ['OK']]
+        [200, { 'content-type' => 'text/html' }, ['OK']]
       end
     end
 

--- a/spec/prometheus/middleware/exporter_spec.rb
+++ b/spec/prometheus/middleware/exporter_spec.rb
@@ -12,7 +12,7 @@ describe Prometheus::Middleware::Exporter do
   end
 
   let(:app) do
-    app = ->(_) { [200, { 'Content-Type' => 'text/html' }, ['OK']] }
+    app = ->(_) { [200, { 'content-type' => 'text/html' }, ['OK']] }
     described_class.new(app, **options)
   end
 
@@ -29,13 +29,13 @@ describe Prometheus::Middleware::Exporter do
     text = Prometheus::Client::Formats::Text
 
     shared_examples 'ok' do |headers, fmt|
-      it "responds with 200 OK and Content-Type #{fmt::CONTENT_TYPE}" do
+      it "responds with 200 OK and content-type #{fmt::CONTENT_TYPE}" do
         registry.counter(:foo, docstring: 'foo counter').increment(by: 9)
 
         get '/metrics', nil, headers
 
         expect(last_response.status).to eql(200)
-        expect(last_response.header['Content-Type']).to eql(fmt::CONTENT_TYPE)
+        expect(last_response.header['content-type']).to eql(fmt::CONTENT_TYPE)
         expect(last_response.body).to eql(fmt.marshal(registry))
       end
     end
@@ -47,7 +47,7 @@ describe Prometheus::Middleware::Exporter do
         get '/metrics', nil, headers
 
         expect(last_response.status).to eql(406)
-        expect(last_response.header['Content-Type']).to eql('text/plain')
+        expect(last_response.header['content-type']).to eql('text/plain')
         expect(last_response.body).to eql(message)
       end
     end
@@ -108,7 +108,7 @@ describe Prometheus::Middleware::Exporter do
           get 'http://example.org:9999/metrics', nil, {}
 
           expect(last_response.status).to eql(200)
-          expect(last_response.header['Content-Type']).to eql(text::CONTENT_TYPE)
+          expect(last_response.header['content-type']).to eql(text::CONTENT_TYPE)
           expect(last_response.body).to eql(text.marshal(registry))
         end
       end


### PR DESCRIPTION
Given Rack is validating HTTP headers has no uppercased letters, as mentioned in this previous PR https://github.com/prometheus/client_ruby/pull/268, the exporter needs to use lowercased letters to keep compatibility.