### PR TITLE
Add Ruby 3.2 to CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ workflows:
             - cimg/ruby:2.7
             - cimg/ruby:3.0
             - cimg/ruby:3.1
+            - cimg/ruby:3.2
             - circleci/jruby:9.1
             - circleci/jruby:9.2
             - circleci/jruby:9.3


### PR DESCRIPTION
Ruby 3.2 was released today, and I would truly hate for us to waste another second in adding it to our list of supported versions.

Happy Christmas everyone! 💖 

---

We may, however, have to wait on CircleCI to publish a 3.2 image 😅