### PR TITLE
Handle `/` in job name in `Prometheus::Client::Push`

### DIFF
--- a/spec/prometheus/client/push_spec.rb
+++ b/spec/prometheus/client/push_spec.rb
@@ -93,6 +93,14 @@ describe Prometheus::Client::Push do
       expect(push.path).to eql('/metrics/job/test-job/foo/bar/baz/qux')
     end
 
+    it 'encodes the job name in url-safe base64 if it contains `/`' do
+      push = Prometheus::Client::Push.new(
+        job: 'foo/test-job',
+      )
+
+      expect(push.path).to eql('/metrics/job@base64/Zm9vL3Rlc3Qtam9i')
+    end
+
     it 'encodes grouping key label values containing `/` in url-safe base64' do
       push = Prometheus::Client::Push.new(
         job: 'test-job',


### PR DESCRIPTION
This a subtlety I missed when overhauling the Pushgateway client.

While the job name can't be empty like other grouping key labels can, it can contain `/`, which means we need to base64 encode the value in that case.