### PR TITLE
Stringify non-string job names in push client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 # Unreleased changes
 
-_None outstanding_
+## Bug fixes
+
+- [#296](https://github.com/prometheus/client_ruby/pull/296) Stringify non-string job
+    names in push client:
+    Previously, an error would be raised if you passed a symbol as the job name, which
+    is inconsistent with how we handle label values in the rest of the client. This
+    change converts the job name to a string before trying to use it.
 
 # 4.2.1 / 2023-08-04
 

--- a/lib/prometheus/client/push.rb
+++ b/lib/prometheus/client/push.rb
@@ -87,6 +87,8 @@ module Prometheus
       end
 
       def build_path(job, grouping_key)
+        job = job.to_s
+
         # Job can't be empty, but it can contain `/`, so we need to base64
         # encode it in that case
         if job.include?('/')

--- a/spec/prometheus/client/push_spec.rb
+++ b/spec/prometheus/client/push_spec.rb
@@ -93,6 +93,14 @@ describe Prometheus::Client::Push do
       expect(push.path).to eql('/metrics/job/test-job/foo/bar/baz/qux')
     end
 
+    it 'converts non-string job names to strings' do
+      push = Prometheus::Client::Push.new(
+        job: :foo,
+      )
+
+      expect(push.path).to eql('/metrics/job/foo')
+    end
+
     it 'encodes the job name in url-safe base64 if it contains `/`' do
       push = Prometheus::Client::Push.new(
         job: 'foo/test-job',


### PR DESCRIPTION
We do this to all other label values in the client and we should make this one consistent. Right now it's particularly surprising that passing a symbol as the job name results in an error like:

```
undefined method `include?' for :foo:Symbol (NoMethodError)
```

Fixes #295 