### PR TITLE
Add Ruby 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ workflows:
             - cimg/ruby:3.0
             - cimg/ruby:3.1
             - cimg/ruby:3.2
+            - cimg/ruby:3.3
             - circleci/jruby:9.1
             - circleci/jruby:9.2
             - circleci/jruby:9.3


### PR DESCRIPTION
Merry Christmas! 🎄☃️

---

No image from CircleCI just yet, but I'll re-run the tests when it appears. The JRuby 9.3 failure looks like drift and I'll fix it in a separate PR.