### PR TITLE
Switch from `circleci/jruby` to `jruby` images in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ workflows:
             - cimg/ruby:3.0
             - cimg/ruby:3.1
             - cimg/ruby:3.2
-            - circleci/jruby:9.1
-            - circleci/jruby:9.2
-            - circleci/jruby:9.3
+            - jruby:9.1
+            - jruby:9.2
+            - jruby:9.3
+            - jruby:9.4


### PR DESCRIPTION
CircleCI started making their next-gen Docker images under the `cimg/` prefix a few years ago and decided not to support JRuby any more.

As of the latest JRuby release (9.4), they are no longer publishing new images. This commit switches us to the official JRuby image, which is CircleCI's suggestion.

See: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

---

**Note**: This is a draft for now as JRuby 9.1 breaks in some inscrutable way that I can't be bothered debugging.

I propose we merge this with whatever our next set of breaking changes happens to be (and also have a big clearout of old versions from the CI matrix). I've added the `breaking-change` label to make it easy to find when we do that.