### PR TITLE
Add JRuby 9.4 to build matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,14 @@ workflows:
             - cimg/ruby:3.1
             - cimg/ruby:3.2
             - cimg/ruby:3.3
+            # We've switched to JRuby's own Docker image as CircleCI decided to
+            # stop supporting it when they deprecated their legacy images. For
+            # some reason, the official JRuby image for 9.1 fails with an
+            # inscrutable error message that isn't worth debugging.
+            #
+            # We'll drop this version on our next major release anyway, as it's
+            # out of security support.
             - circleci/jruby:9.1
-            - circleci/jruby:9.2
-            - circleci/jruby:9.3
+            - jruby:9.2
+            - jruby:9.3
+            - jruby:9.4


### PR DESCRIPTION
We've had to switch to the main JRuby Docker image as CircleCI have stopped publishing their own CI-optimised ones with extra tools installed. It turns out this isn't a problem for us as we're not dependent on much in the image.

See: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

This commit also switches versions 9.2 and 9.3 to the main JRuby Docker image, but not 9.1 as that breaks for some inscrutable reason. We'll drop 9.1 and all other unsupported Rubies in our next major release.