### PR TITLE
Declare base64 gem dependency, ready for Ruby 3.4.

### DIFF
--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
   s.files             = %w(README.md LICENSE) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
 
+  s.add_dependency 'base64'
+
   s.add_development_dependency 'benchmark-ips'
   s.add_development_dependency 'concurrent-ruby'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
The base64 gem is [no longer a default gem](https://docs.ruby-lang.org/en/master/NEWS_md.html#label-Stdlib+updates) in Ruby 3.4.

Add base64 to the gemspec, for forward compatibility with Ruby 3.4 and to resolve the `base64 was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0` warning that Ruby 3.3 emits on loading client_ruby.