### PR TITLE
Pin `tins` dependency for JRuby 9.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,15 +9,4 @@ group :test do
   gem 'rack-test'
   gem 'rake'
   gem 'rspec'
-  gem 'term-ansicolor'
-  # The latest version of `tins` adds a dependency on `bigdecimal`, which
-  # causes JRuby to fetch and build it rather than using its built-in version.
-  # This fails on JRuby 9.1, so we need to handle that version  specifically.
-  #
-  # TODO: Remove this when we drop JRuby 9.1 from the build matrix
-  if defined?(JRUBY_VERSION) && Gem::Version.new(JRUBY_VERSION) <= Gem::Version.new("9.2.0")
-    gem 'tins', '<= 1.32.1'
-  else
-    gem 'tins'
-  end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,14 @@ group :test do
   gem 'rake'
   gem 'rspec'
   gem 'term-ansicolor'
-  gem 'tins'
+  # The latest version of `tins` adds a dependency on `bigdecimal`, which
+  # causes JRuby to fetch and build it rather than using its built-in version.
+  # This fails on JRuby 9.1, so we need to handle that version  specifically.
+  #
+  # TODO: Remove this when we drop JRuby 9.1 from the build matrix
+  if defined?(JRUBY_VERSION) && Gem::Version.new(JRUBY_VERSION) <= Gem::Version.new("9.2.0")
+    gem 'tins', '<= 1.32.1'
+  else
+    gem 'tins'
+  end
 end


### PR DESCRIPTION
The latest version of `tins` adds a dependency on `bigdecimal`, which causes JRuby to fetch and build it rather than using its built-in version. This fails on JRuby 9.1, so we need to handle that version specifically.

This gets CI back to green.

---

Once this is merged, I'm going to cut a patch release to finally get rid of the annoying warning that we emit on Ruby 3.3.