### PR TITLE
Yeet `term-ansicolor` and `tins` from test dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,4 @@ group :test do
   gem 'rack-test'
   gem 'rake'
   gem 'rspec'
-  gem 'term-ansicolor'
-  gem 'tins'
 end


### PR DESCRIPTION
I was trying to fix CI by pinning `term-ansicolor` to a specific version, but Daniel pointed out that we don't even seem to use it anywhere, so let's throw it (and its `tins` dependency) out.