### PR TITLE
Do not use benchmark gem in production

### DIFF
--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -1,6 +1,5 @@
 # encoding: UTF-8
 
-require 'benchmark'
 require 'prometheus/client'
 
 module Prometheus
@@ -34,6 +33,12 @@ module Prometheus
 
       protected
 
+      def realtime
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        yield
+        Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+      end
+
       def init_request_metrics
         @requests = @registry.counter(
           :"#{@metrics_prefix}_requests_total",
@@ -58,7 +63,7 @@ module Prometheus
 
       def trace(env)
         response = nil
-        duration = Benchmark.realtime { response = yield }
+        duration = realtime { response = yield }
         record(env, response.first.to_s, duration)
         return response
       rescue => exception

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'base64'
 
+  s.add_development_dependency 'benchmark'
   s.add_development_dependency 'benchmark-ips'
   s.add_development_dependency 'concurrent-ruby'
   s.add_development_dependency 'timecop'

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -42,7 +42,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'traces request information' do
-    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.2)
+    expect(app).to receive(:realtime).and_yield.and_return(0.2)
 
     get '/foo'
 
@@ -68,7 +68,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'normalizes paths containing numeric IDs by default' do
-    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.3)
+    expect(app).to receive(:realtime).and_yield.and_return(0.3)
 
     get '/foo/42/bars'
 
@@ -82,7 +82,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'normalizes paths containing UUIDs by default' do
-    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.3)
+    expect(app).to receive(:realtime).and_yield.and_return(0.3)
 
     get '/foo/5180349d-a491-4d73-af30-4194a46bdff3/bars'
 
@@ -96,7 +96,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'handles consecutive path segments containing IDs' do
-    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.3)
+    expect(app).to receive(:realtime).and_yield.and_return(0.3)
 
     get '/foo/42/24'
 
@@ -110,7 +110,7 @@ describe Prometheus::Middleware::Collector do
   end
 
   it 'handles consecutive path segments containing UUIDs' do
-    expect(Benchmark).to receive(:realtime).and_yield.and_return(0.3)
+    expect(app).to receive(:realtime).and_yield.and_return(0.3)
 
     get '/foo/5180349d-a491-4d73-af30-4194a46bdff3/5180349d-a491-4d73-af30-4194a46bdff2'
 


### PR DESCRIPTION
The benchmark gem is no longer a default gem in Ruby 3.5.

Add benchmark to the gemspec, for forward compatibility with Ruby 3.5 and to resolve the `benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.' warning that Ruby 3.4 emits on loading client_ruby.

https://docs.ruby-lang.org/en/master/NEWS_md.html#label-Stdlib+updates