### PR TITLE
Fix Ruby 4.0 compatibility: replace CGI with URI in DirectFileStore

### DIFF
--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.require_paths     = ['lib']
 
   s.add_dependency 'base64'
-  s.add_dependency 'cgi'
 
   s.add_development_dependency 'benchmark'
   s.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
CGI.parse and CGI.escape methods were removed from the `cgi` gem in Ruby 4.0. The `cgi` gem now only provides `CGI.escape`/`CGI.unescape` for HTML escaping, and `CGI.escapeURIComponent`/`CGI.unescapeURIComponent` for URI components.

This PR replaces:
- `CGI::parse(query_string)` → `URI.decode_www_form(query_string).to_h`
- `CGI::escape` in query string building → `URI.encode_www_form`

The `uri` module is part of Ruby's standard library and doesn't require an additional dependency.

**Testing:**
- All existing specs pass
- Tested manually with Ruby 4.0.1 in production environment