### PR TITLE
Update supported Ruby versions in build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.2"
           - "3.3"
           - "3.4"
           - "4.0"
           - "jruby-9.4"
-          - "jruby-10.0.2.0"
+          - "jruby-10.0"
+          - "jruby-10.1"
 
     steps:
       - name: Check out


### PR DESCRIPTION
I'm about to cut a major version to clear out a bunch of old Ruby versions (already removed in 169bd93761840e51511e728ffb742139a006920d) and since removing them, Ruby 3.2 has also fallen out of support.

Let's get rid of that and test against both JRuby 10.0 (Ruby 3.4 compatible) and JRuby 10.1 (Ruby 4.0 compatible) while we're at it.